### PR TITLE
Standardize flow executors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
   <img src="./docs/img/logo.png" alt="drawing" width="70%"/>
 </p>
 
-Python backend for graph-based processing, designed for flow-based/node-based visual scripting editors. It is the backbone of the [Ryven](https://github.com/leon-thomm/Ryven) project, but it can be used for other applications as well.
+An experimental Python library for graph-based processing, designed for flow-based/node-based visual scripting editors. While it is the backbone of the [Ryven](https://github.com/leon-thomm/Ryven) project, it can very much be used in other contexts as well.
 
-If you are not already familiar with flow-based visual scripting and are looking for a specification, see [here](https://leon-thomm.github.io/ryvencore-qt/).
+While ryvencore is written purely in Python, with not a single dependency it is very lightweight and highly compatible. It can be compiled with Cython, see the `setup_cython.py` file. The performance seems comparable so far, but the code hasn't been optimized for Cython yet, so there might be a lot of potential. Please consider contributing. Pyodide provides a WebAssembly port of ryvencore.
+
+[//]: # (If you are not familiar with flow-based visual scripting and are looking for a specification, see [here]&#40;https://leon-thomm.github.io/ryvencore-qt/&#41;.)
 
 ### Installation
 
@@ -20,15 +22,11 @@ cd ryvencore
 pip install .
 ```
 
-### Dependencies
-
-None! ryvencore runs completely on standard python modules, no additional libraries required, which makes it very compatible.
-
-<!-- *I am therefore thinking about extending the implementation to compile with Cython. While the overhead produced by the internal graph representation compared to only executing python code specified in the nodes' `update_event` does not dominate, efficient Cython support might lead to speedup of another ~20%-40%.* -->
-
 ### Usage
 
-Using ryvencore directly to run projects made with ryvencore-based editors, the following code example gives some intuition about the process:
+As an experimental library, the API is not stable and small breaking changes over time should be expected. There is no maintained usage guide, but the code is documented and auto-generated docs are available [here](https://leon-thomm.github.io/ryvencore/).
+
+A small example:
 
 ```python
 import ryvencore as rc
@@ -36,15 +34,8 @@ import json
 import sys
 
 if __name__ == '__main__':
-    # get a working project file path
-    if len(sys.argv) < 2:
-        sys.exit('please provide a project file path')
-    fpath = sys.argv[1]
-    try:
-        f = open(fpath)
-        f.close()
-    except FileNotFoundError:
-        sys.exit(f'could not open file {fpath}')
+    # project file path
+    fpath = sys.args[1]
     
     # read project file
     with open(fpath, 'r') as f:
@@ -54,14 +45,18 @@ if __name__ == '__main__':
     session = rc.Session()
     session.load(project)
 
-    # and now we can manually access all components, for example:
+    # now we can access all components, for example:
+    
+    # get the first flow
     scripts = session.scripts
     flow1 = scripts[0].flow
+    
+    # and the last node that was created
     my_node = flow1.nodes[-1]
+    
+    # and execute it
     my_node.update()
 ```
-
-You can also use it for other purposes. A mostly auto-generated documentation is available [here](https://leon-thomm.github.io/ryvencore/).
 
 ### Main Features
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 
 An experimental Python library for graph-based processing, designed for flow-based/node-based visual scripting editors. While it is the backbone of the [Ryven](https://github.com/leon-thomm/Ryven) project, it can very much be used in other contexts as well.
 
-While ryvencore is written purely in Python, with not a single dependency it is very lightweight and highly compatible. It can be compiled with Cython, see the `setup_cython.py` file. The performance seems comparable so far, but the code hasn't been optimized for Cython yet, so there might be a lot of potential. Please consider contributing. Pyodide provides a WebAssembly port of ryvencore.
-
-[//]: # (If you are not familiar with flow-based visual scripting and are looking for a specification, see [here]&#40;https://leon-thomm.github.io/ryvencore-qt/&#41;.)
+While ryvencore is written purely in Python, with not a single dependency it is very lightweight and highly compatible. It can be compiled with Cython, see the `setup_cython.py` file. The performance seems comparable so far, but the code hasn't been optimized for Cython yet, so there might be a lot of potential. Please consider contributing. [Pyodide](https://github.com/pyodide/pyodide) provides a WebAssembly port of ryvencore.
 
 ### Installation
 
@@ -24,7 +22,7 @@ pip install .
 
 ### Usage
 
-As an experimental library, the API is not stable and small breaking changes over time should be expected. There is no maintained usage guide, but the code is documented and auto-generated docs are available [here](https://leon-thomm.github.io/ryvencore/).
+As an experimental library, the API is not fully stable and small breaking changes over time should be expected. There is no maintained usage guide, but the code is documented and auto-generated docs are available [here](https://leon-thomm.github.io/ryvencore/).
 
 A small example:
 
@@ -58,14 +56,17 @@ if __name__ == '__main__':
     my_node.update()
 ```
 
-### Main Features
+### Features
 
-- **load & save** into and from JSON-compatible dictionaries
-- **variables system** with update mechanism to build nodes that automatically adapt to change of data
-- **built in logging** based on python's `logging` module
-- **powerful nodes system** which lets you do anything, simple and unrestricted
-- **dynamic nodes registration mechanism** to register and unregister nodes at runtime
-- **actions system for nodes**
+The main features include
+
+- **load & save** from and into JSON
+- **a simple and powerful nodes system** which lets you do anything, simple and unrestricted
 - **data *and* exec flow support** - unlike lots of other solutions out there, ryvencore supports exec flows
+- **variables system** with subscribe and update mechanism to build nodes that automatically adapt to change of data
+- **built-in logging** based on python's `logging` module
+- **actions system for nodes**
 
-For a more detailed overview, see the [docs](https://leon-thomm.github.io/ryvencore-qt/#/features).
+### Licensing
+
+ryvencore is licensed under the [LGPL License](github.com/leon-thomm/ryvencore/blob/master/LICENSE).

--- a/cleanup_cython.py
+++ b/cleanup_cython.py
@@ -1,0 +1,68 @@
+"""
+simple helper script to remove all Cython-generated files and directories generated
+"""
+
+import os
+import shutil
+
+
+def get_generated_files(basedir):
+    """
+    remove all generated .c/.so/.html files
+    """
+
+    generated_files = []
+
+    for root, dirs, files in os.walk(basedir):
+
+        # print('FILES: ---------')
+        # print('\n'.join(files))
+        # print()
+
+        for f in files:
+
+            # e.g. file LICENSE doesn't have an extension at all
+            if len(f.split('.')) < 2:
+                continue
+
+            fpath = os.path.join(root, f)
+            fname, ext = f.split('.')[0], f.split('.')[-1]
+
+            py_file_path = os.path.join(root, fname + '.py')
+
+            if ext in ['c', 'so', 'html'] and os.path.exists(py_file_path):
+                generated_files.append(fpath)
+
+    return generated_files
+
+
+def cleanup():
+
+    os.chdir(os.path.dirname(__file__))
+
+    print('UNINSTALLING RYVENCORE')
+
+    os.system('pip uninstall ryvencore --yes')
+
+    remove_files = get_generated_files('./ryvencore/')
+
+    print('REMOVING FILES\n', '\n'.join(remove_files))
+
+    for f in remove_files:
+        os.remove(f)
+
+    print('REMOVING DIRECTORIES')
+
+    dirs = [
+        'ryvencore/build',
+        'ryvencore/dist',
+        'ryvencore/ryvencore.egg-info',
+    ]
+
+    for d in dirs:
+        print(d)
+        shutil.rmtree(d)
+
+
+if __name__ == '__main__':
+    cleanup()

--- a/cleanup_cython.py
+++ b/cleanup_cython.py
@@ -40,9 +40,9 @@ def cleanup():
 
     os.chdir(os.path.dirname(__file__))
 
-    print('UNINSTALLING RYVENCORE')
-
-    os.system('pip uninstall ryvencore --yes')
+    # print('UNINSTALLING RYVENCORE')
+    #
+    # os.system('pip uninstall ryvencore --yes')
 
     remove_files = get_generated_files('./ryvencore/')
 

--- a/ryvencore/Base.py
+++ b/ryvencore/Base.py
@@ -1,8 +1,17 @@
+"""
+This module defines features and behavior that applies to most internal
+components. It defines the Base (parent) class featuring events, automatic and
+custom ID assignments, serialization, and customizable extension of serialization.
+"""
+
+
 def complete_data(data: dict) -> dict:
-    """Default implementation for completing data with frontend properties.
-    When running with a frontend that needs to store additional information about
-    components (e.g. current position and color of a node), this frontend then
-    overrode this exact function to add whatever is necessary for adding this data."""
+    """
+    Default implementation for supplementing data with additional (e.g. frontend)
+    information. For example, a frontend can store additional information like
+    current position, color of a node, etc. by replacing this function by an
+    according custom handler.
+    """
     return data
 
 
@@ -12,12 +21,26 @@ class Event:
         self._slots = []
 
     def connect(self, callback):
+        """
+        Registers a callback function. The callback must accept compatible arguments.
+        """
         self._slots.append(callback)
 
     def disconnect(self, callback):
+        """
+        De-registers a callback function. The function must have been added previously.
+        """
         self._slots.remove(callback)
 
     def emit(self, *args):
+        """
+        Emits an event by calling all registered callback functions in the order they
+        were registered, with parameters given by *args.
+        """
+
+        # I am assuming that the for-each loop keeps the overhead small in case
+        # there are no slots registered, but one might want to profile that.
+
         for cb in self._slots:
             cb(*args)
 
@@ -29,6 +52,10 @@ class Base:
     """
 
     class IDCtr:
+        """
+        A simple ascending integer counter.
+        """
+
         def __init__(self):
             self.ctr = -1
 
@@ -53,7 +80,7 @@ class Base:
 
     # events
     events = {}
-    # format: {event_name : tuple_of_arguments}
+    # format: {event_name : tuple_of_argument_types}
     # the arguments tuple only serves documentation purposes
 
     def __init__(self):
@@ -68,10 +95,15 @@ class Base:
             for ev in self.events
         }
 
-    # CUSTOM DATA ------------------------------------
+    """
+    
+    CUSTOM DATA
+    
+    """
 
-    # this can be set to another function by the frontend to implement adding frontend information to the data dict
-    complete_data_function = lambda data: data
+    # this can be conveniently set to another function by the host to implement
+    # adding additional (e.g. frontend-related) information to the data dict
+    complete_data_function = complete_data
 
     def data(self) -> dict:
         """converts the object to a JSON compatible dict for serialization"""
@@ -80,7 +112,11 @@ class Base:
     def complete_data(self, data: dict) -> data:
         return Base.complete_data_function(data)
 
-    # EVENTS ------------------------------------
+    """
+    
+    EVENTS
+    
+    """
 
     def on(self, ev: Event, callback):
         # self._slots[ev].append(callback)

--- a/ryvencore/Connection.py
+++ b/ryvencore/Connection.py
@@ -1,3 +1,7 @@
+"""
+deprecated and now unused
+"""
+
 from .Base import Base, Event
 
 from .InfoMsgs import InfoMsgs
@@ -12,24 +16,25 @@ class Connection(Base):
     def __init__(self, params):
         Base.__init__(self)
 
-        self.activated = Event(object)
+        self.activated = Event(object)  # TODO: connections are not activated anymore
 
         self.out, self.inp, self.flow = params
 
-    def activate(self, data=None):
-        """Causes forward propagation of information"""
-
-        self.activated.emit(data)
+    # def activate(self, data=None):
+    #     """Causes forward propagation of information"""
+    #
+    #     self.activated.emit(data)
 
 
 class ExecConnection(Connection):
+    pass
 
-    def activate(self, data=None):
-        """Causes an update in the input port"""
-        InfoMsgs.write('exec connection activated')
-        super().activate()
-
-        self.inp.update()
+    # def activate(self, data=None):
+    #     """Causes an update in the input port"""
+    #     InfoMsgs.write('exec connection activated')
+    #     super().activate()
+    #
+    #     self.inp.update()
 
 
 class DataConnection(Connection):
@@ -39,22 +44,16 @@ class DataConnection(Connection):
 
         self.data = None
 
-    def get_val(self):
-        """Gets the value of the output port -- only used in exec mode flows"""
-        InfoMsgs.write('data connection getting value')
+    # def get_val(self):
+    #     """Gets the value of the output port -- only used in exec mode flows"""
+    #     InfoMsgs.write('data connection getting value')
+    #
+    #     return self.out.get_val()
 
-        # request data backwards
-        self.data = self.out.get_val()
-
-        return self.data
-
-    def activate(self, data=None):
-        """Passes data to the input port and causes update"""
-        InfoMsgs.write('data connection activated')
-        super().activate(data)
-
-        # store data
-        self.data = data
-
-        # propagate data forward
-        self.inp.update(data)
+    # def activate(self, data=None):
+    #     """Passes data to the input port and causes update"""
+    #     InfoMsgs.write('data connection activated')
+    #     super().activate(data)
+    #
+    #     # propagate data forward
+    #     self.inp.update(data)

--- a/ryvencore/Connection.py
+++ b/ryvencore/Connection.py
@@ -20,21 +20,9 @@ class Connection(Base):
 
         self.out, self.inp, self.flow = params
 
-    # def activate(self, data=None):
-    #     """Causes forward propagation of information"""
-    #
-    #     self.activated.emit(data)
-
 
 class ExecConnection(Connection):
     pass
-
-    # def activate(self, data=None):
-    #     """Causes an update in the input port"""
-    #     InfoMsgs.write('exec connection activated')
-    #     super().activate()
-    #
-    #     self.inp.update()
 
 
 class DataConnection(Connection):
@@ -43,17 +31,3 @@ class DataConnection(Connection):
         super().__init__(params)
 
         self.data = None
-
-    # def get_val(self):
-    #     """Gets the value of the output port -- only used in exec mode flows"""
-    #     InfoMsgs.write('data connection getting value')
-    #
-    #     return self.out.get_val()
-
-    # def activate(self, data=None):
-    #     """Passes data to the input port and causes update"""
-    #     InfoMsgs.write('data connection activated')
-    #     super().activate(data)
-    #
-    #     # propagate data forward
-    #     self.inp.update(data)

--- a/ryvencore/Flow.py
+++ b/ryvencore/Flow.py
@@ -196,7 +196,7 @@ class Flow(Base):
 
         if inp in self.graph_adj[out]:
             # disconnect
-            self.remove_connection(out, inp)
+            self.remove_connection((out, inp))
             return None
 
         # c = self.session.CLASSES['data conn']((out, inp, self)) if out.type_ == 'data' else \
@@ -206,13 +206,15 @@ class Flow(Base):
         #
         # self.add_connection(c)
 
-        self.add_connection(out, inp)
+        self.add_connection((out, inp))
 
         return out, inp
 
 
-    def add_connection(self, out: NodePort, inp: NodePort):
+    def add_connection(self, c: Tuple[NodePort, NodePort]):
         """Adds a connection object"""
+
+        out, inp = c
 
         self.graph_adj[out].append(inp)
         self.graph_adj_rev[inp] = out
@@ -232,8 +234,10 @@ class Flow(Base):
         self.connection_added.emit(out, inp)
 
 
-    def remove_connection(self, out: NodePort, inp: NodePort):
+    def remove_connection(self, c: Tuple[NodePort, NodePort]):
         """Removes a connection object without deleting it"""
+
+        out, inp = c
 
         self.graph_adj[out].remove(inp)
         self.graph_adj_rev[inp] = None
@@ -251,6 +255,14 @@ class Flow(Base):
 
         # self.emit_event('connection removed', (c,))    # ALPHA
         self.connection_removed.emit(out, inp)
+
+
+    def connected_inputs(self, out: NodePort) -> List[NodePort]:
+        return self.graph_adj[out]
+
+
+    def connected_output(self, inp: NodePort) -> Optional[NodePort]:
+        return self.graph_adj_rev[inp]
 
 
     def algorithm_mode(self) -> str:

--- a/ryvencore/Flow.py
+++ b/ryvencore/Flow.py
@@ -19,8 +19,8 @@ class Flow(Base):
         # events
         self.node_added = Event(Node)
         self.node_removed = Event(Node)
-        self.connection_added = Event(NodePort, NodePort)        # Event(Connection)
-        self.connection_removed = Event(NodePort, NodePort)      # Event (Connection)
+        self.connection_added = Event((NodePort, NodePort))        # Event(Connection)
+        self.connection_removed = Event((NodePort, NodePort))      # Event (Connection)
 
         self.connection_request_valid = Event(bool)
         self.nodes_created_from_data = Event(list)
@@ -42,16 +42,10 @@ class Flow(Base):
         self.executor: FlowExecutor = executor_from_flow_alg(self.alg_mode)(self)
 
     def load(self, data):
-        """Loading a flow from data"""
+        """Loading a flow from data as previously returned by data()"""
 
-        # algorithm mode
-        mode = data['algorithm mode']
-        if mode == 'data' or mode == 'data flow':
-            self.set_algorithm_mode('data')
-        elif mode == 'data opt':
-            self.set_algorithm_mode('data opt')
-        elif mode == 'exec' or mode == 'exec flow':
-            self.set_algorithm_mode('exec')
+        # set algorithm mode
+        self.alg_mode = FlowAlg.from_str(data['algorithm mode'])
 
         # build flow
 
@@ -69,7 +63,7 @@ class Flow(Base):
 
 
     def create_nodes_from_data(self, nodes_data: List):
-        """Creates Nodes from nodes_data, previously returned by data()"""
+        """create nodes from nodes_data as previously returned by data()"""
 
         nodes = []
 
@@ -231,7 +225,7 @@ class Flow(Base):
         self.executor.conn_added(out, inp)
 
         # self.emit_event('connection added', (c,))    # ALPHA
-        self.connection_added.emit(out, inp)
+        self.connection_added.emit((out, inp))
 
 
     def remove_connection(self, c: Tuple[NodePort, NodePort]):
@@ -254,7 +248,7 @@ class Flow(Base):
         self.executor.conn_removed(out, inp)
 
         # self.emit_event('connection removed', (c,))    # ALPHA
-        self.connection_removed.emit(out, inp)
+        self.connection_removed.emit((out, inp))
 
 
     def connected_inputs(self, out: NodePort) -> List[NodePort]:

--- a/ryvencore/Flow.py
+++ b/ryvencore/Flow.py
@@ -1,5 +1,4 @@
 from .Base import Base, Event
-# from .Connection import Connection, DataConnection, ExecConnection
 from .FlowExecutor import DataFlowNaive, DataFlowOptimized, FlowExecutor, executor_from_flow_alg
 from .Node import Node
 from .NodePort import NodePort
@@ -32,7 +31,6 @@ class Flow(Base):
         self.session = session
         self.script = script
         self.nodes: [Node] = []
-        # self.connections: [Connection] = []
 
         self.node_successors = {}   # additional data structure for executors
         self.graph_adj = {}         # directed adjacency list relating node ports
@@ -87,8 +85,6 @@ class Flow(Base):
         """Creates, adds and returns a new node object"""
 
         node = node_class((self, self.session, data))
-        # node.finish_initialization()
-        # node.load_user_data()  # --> Node.set_state()
         node.initialize()
         self.add_node(node)
         return node
@@ -108,7 +104,6 @@ class Flow(Base):
         node.after_placement()
         self.flow_changed()
 
-        # self.emit_event('node added', (node,))    # ALPHA
         self.node_added.emit(node)
 
 
@@ -132,7 +127,6 @@ class Flow(Base):
 
         self.flow_changed()
 
-        # self.emit_event('node removed', (node,))    # ALPHA
         self.node_removed.emit(node)
 
 
@@ -193,13 +187,6 @@ class Flow(Base):
             self.remove_connection((out, inp))
             return None
 
-        # c = self.session.CLASSES['data conn']((out, inp, self)) if out.type_ == 'data' else \
-        #     self.session.CLASSES['exec conn']((out, inp, self))
-        # c = DataConnection((out, inp, self)) if out.type_ == 'data' else \
-        #     ExecConnection((out, inp, self))
-        #
-        # self.add_connection(c)
-
         self.add_connection((out, inp))
 
         return out, inp
@@ -212,12 +199,6 @@ class Flow(Base):
 
         self.graph_adj[out].append(inp)
         self.graph_adj_rev[inp] = out
-
-        # c.out.connections.append(c)
-        # c.inp.connections.append(c)
-        # c.out.connected()
-        # c.inp.connected()
-        # self.connections.append(c)
 
         self.node_successors[out.node].append(inp.node)
         self.flow_changed()
@@ -235,12 +216,6 @@ class Flow(Base):
 
         self.graph_adj[out].remove(inp)
         self.graph_adj_rev[inp] = None
-
-        # c.out.connections.remove(c)
-        # c.inp.connections.remove(c)
-        # c.out.disconnected()
-        # c.inp.disconnected()
-        # self.connections.remove(c)
 
         self.node_successors[out.node].remove(inp.node)
         self.flow_changed()

--- a/ryvencore/FlowExecutor.py
+++ b/ryvencore/FlowExecutor.py
@@ -21,7 +21,8 @@ class FlowExecutor:
     def __init__(self, flow):
         self.flow = flow
         self.flow_changed = True
-        self.graph = self.flow.graph_adjacency
+        self.graph = self.flow.graph_adj
+        self.graph_rev = self.flow.graph_adj_rev
 
         # self.flow.connection_added.connect(self.conn_added)
         # self.flow.connection_removed.connect(self.conn_removed)
@@ -344,7 +345,7 @@ class ExecFlowNaive(FlowExecutor):
     # Node.input() =>
     def input(self, node, index):
         inp = node.inputs[index]
-        out = self.graph[inp]
+        out = self.graph_rev[inp]
         if out:
             n = out.node
             if n not in self.updated_nodes:

--- a/ryvencore/FlowExecutor.py
+++ b/ryvencore/FlowExecutor.py
@@ -24,9 +24,6 @@ class FlowExecutor:
         self.graph = self.flow.graph_adj
         self.graph_rev = self.flow.graph_adj_rev
 
-        # self.flow.connection_added.connect(self.conn_added)
-        # self.flow.connection_removed.connect(self.conn_removed)
-
     # Node.update() =>
     def update_node(self, node, inp):
         pass
@@ -61,9 +58,6 @@ class DataFlowNaive(FlowExecutor):
     - no non-terminating feedback loops
     """
 
-    # def __int__(self, flow):
-    #     super().__init__(flow)
-
     # Node.update() =>
     def update_node(self, node, inp):
         try:
@@ -73,8 +67,6 @@ class DataFlowNaive(FlowExecutor):
 
     # Node.input() =>
     def input(self, node, index):
-        # return node.inputs[index].get_val()
-
         inp = node.inputs[index]
         conn_out = self.graph_rev[inp]
 
@@ -85,8 +77,6 @@ class DataFlowNaive(FlowExecutor):
 
     # Node.set_output_val() =>
     def set_output_val(self, node, index, val):
-        # node.outputs[index].set_val(val)
-
         out = node.outputs[index]
         if not out.type_ == 'data':
             return

--- a/ryvencore/FlowExecutor.py
+++ b/ryvencore/FlowExecutor.py
@@ -76,7 +76,7 @@ class DataFlowNaive(FlowExecutor):
         # return node.inputs[index].get_val()
 
         inp = node.inputs[index]
-        conn_out = self.graph[inp]
+        conn_out = self.graph_rev[inp]
 
         if conn_out:
             return conn_out.val

--- a/ryvencore/FlowExecutor.py
+++ b/ryvencore/FlowExecutor.py
@@ -1,7 +1,15 @@
 """
-While standard flow execution (data-flow or exec-flow) is implemented inside the classes (like Node),
-this module provides special FlowExecutors which take over most of the work and implement more
-sophisticated and optimized flow execution.
+The flow executors are responsible for executing the flow. They have access to
+the flow as well as the nodes' internals and are able to perform optimizations.
+"""
+from .RC import FlowAlg
+
+
+"""
+graph_adjacency = {
+    node_output: [node_input],    
+    node_input:  node_output | None
+}
 """
 
 
@@ -12,6 +20,11 @@ class FlowExecutor:
 
     def __init__(self, flow):
         self.flow = flow
+        self.flow_changed = True
+        self.graph = self.flow.graph_adjacency
+
+        # self.flow.connection_added.connect(self.conn_added)
+        # self.flow.connection_removed.connect(self.conn_removed)
 
     # Node.update() =>
     def update_node(self, node, inp):
@@ -29,8 +42,77 @@ class FlowExecutor:
     def exec_output(self, node, index):
         pass
 
+    def conn_added(self, out, inp):
+        pass
 
-class DataFlowOptimized(FlowExecutor):
+    def conn_removed(self, out, inp):
+        pass
+
+
+class DataFlowNaive(FlowExecutor):
+    """
+    The naive implementation of data-flow execution. Naive meaning setting a node output
+    leads to an immediate update in all successors consecutively. No runtime optimization
+    if performed, and some types of graphs can run really slow here, especially if they
+    include "diamonds".
+
+    Assumptions for the graph:
+    - no non-terminating feedback loops
+    """
+
+    # def __int__(self, flow):
+    #     super().__init__(flow)
+
+    # Node.update() =>
+    def update_node(self, node, inp):
+        try:
+            node.update_event(inp)
+        except Exception as e:
+            node.update_error(e)
+
+    # Node.input() =>
+    def input(self, node, index):
+        # return node.inputs[index].get_val()
+
+        inp = node.inputs[index]
+        conn_out = self.graph[inp]
+
+        if conn_out:
+            return conn_out.val
+        else:
+            return None
+
+    # Node.set_output_val() =>
+    def set_output_val(self, node, index, val):
+        # node.outputs[index].set_val(val)
+
+        out = node.outputs[index]
+        if not out.type_ == 'data':
+            return
+        out.val = val
+
+        for inp in self.graph[out]:
+            inp.node.update(inp=inp.node.inputs.index(inp))
+
+    # Node.exec_output() =>
+    def exec_output(self, node, index):
+        out = node.outputs[index]
+        if not out.type_ == 'exec':
+            return
+
+        for inp in self.graph[out]:
+            inp.node.update(inp=inp.node.inputs.index(inp))
+
+    def conn_added(self, out, inp):
+        # update input
+        inp.node.update(inp=inp.node.inputs.index(inp))
+
+    def conn_removed(self, out, inp):
+        # update input
+        inp.node.update(inp=inp.node.inputs.index(inp))
+
+
+class DataFlowOptimized(DataFlowNaive):
     """
     A special flow executor which implements some node functions to optimise flow execution.
     Whenever a new execution is invoked somewhere (some node or output is updated), it
@@ -45,6 +127,10 @@ class DataFlowOptimized(FlowExecutor):
     execution where any two executed branches which merge again in the future result in two
     complete executions of everything that comes after the merge, which quickly produces
     exponential performance issues.
+
+    Assumptions for the graph:
+
+    - no feedback loops
     """
 
     def __init__(self, flow):
@@ -57,7 +143,6 @@ class DataFlowOptimized(FlowExecutor):
         self.last_execution_root = None     # for reuse when a same execution is invoked many times consecutively
         self.execution_root = None          # can be Node or NodeOutput
         self.execution_root_node = None     # the updated Node or the updated NodeOutput's Node
-        self.flow_changed = True
 
     # NODE FUNCTIONS
 
@@ -72,8 +157,7 @@ class DataFlowOptimized(FlowExecutor):
             self.invoke_node_update_event(node, inp)
 
     # Node.input() =>
-    def input(self, node, index):
-        return node.inputs[index].get_val()
+    #   DataFlowNative.input(node, index)
 
     # Node.set_output_val() =>
     def set_output_val(self, node, index, val):
@@ -96,15 +180,16 @@ class DataFlowOptimized(FlowExecutor):
                 # there are other possible solutions to this, including running
                 # a new execution analysis of this graph here
 
-                out.set_val(val)
+                super().set_output_val(node, index, val)
 
             else:
                 out.val = val
                 self.output_updated[out] = True
 
-
     # Node.exec_output() =>
     def exec_output(self, node, index):
+        # rudimentary exec support also in data flows
+
         out = node.outputs[index]
 
         if self.execution_root_node is None:  # execution starter!
@@ -118,7 +203,11 @@ class DataFlowOptimized(FlowExecutor):
         else:
             self.output_updated[out] = True
 
-    # ----------------------------------------------------------
+    """
+    
+    Helper methods
+    
+    """
 
     def start_execution(self, root_node=None, root_output=None):
 
@@ -166,9 +255,10 @@ class DataFlowOptimized(FlowExecutor):
         # BC
         if root_node is not None:
             successors.add(root_node)
+
         elif root_output is not None:
-            for c in root_output.connections:
-                connected_node = c.inp.node
+            for inp in self.graph[root_output]:
+                connected_node = inp.node
                 self.num_conns_from_predecessors[connected_node] += 1
                 successors.add(connected_node)
 
@@ -188,10 +278,7 @@ class DataFlowOptimized(FlowExecutor):
         return self.num_conns_from_predecessors.copy()
 
     def invoke_node_update_event(self, node, inp):
-        try:
-            node.update_event(inp)
-        except Exception:
-            pass
+        super().update_node(node, inp)
 
     def decrease_wait(self, node):
         """decreases the wait count of the node;
@@ -212,15 +299,76 @@ class DataFlowOptimized(FlowExecutor):
         """pushes an output's value to successors if it has been changed in the execution"""
 
         if self.output_updated[out]:
-
-            if out.type_ == 'data':         # data output updated
-                for c in out.connections:
-                    c.activate(out.val)
-
-            else:                           # exec output executed
-                for c in out.connections:
-                    c.activate()
+            # same procedure for data and exec connections
+            for inp in self.graph[out]:
+                inp.node.update(inp=inp.node.inputs.index(inp))
 
         # decrease wait count of successors
-        for c in out.connections:
-            self.decrease_wait(c.inp.node)
+        for inp in self.graph[out]:
+            self.decrease_wait(inp.node)
+
+
+class ExecFlowNaive(FlowExecutor):
+    """
+    ...
+    """
+
+    def __init__(self, flow):
+        super().__init__(flow)
+
+        # all the nodes currently updating because of an output data request
+        # used to prevent redundant predecessor updates during the update
+        # of a single successor
+        self.updated_nodes = None
+
+    # Node.update() = >
+    def update_node(self, node, inp):
+        if inp != -1 and node.inputs[inp].type_ == 'data':
+            return
+
+        execution_starter = self.updated_nodes is None
+
+        if execution_starter:
+            self.updated_nodes = {node}
+        else:
+            self.updated_nodes.add(node)
+
+        try:
+            node.update_event(inp)
+        except Exception as e:
+            node.update_error(e)
+
+        if execution_starter:
+            self.updated_nodes = None
+
+    # Node.input() =>
+    def input(self, node, index):
+        inp = node.inputs[index]
+        out = self.graph[inp]
+        if out:
+            n = out.node
+            if n not in self.updated_nodes:
+                n.update(-1)
+
+            return out.val
+        else:
+            return None
+
+    # Node.set_output_val() =>
+    def set_output_val(self, node, index, val):
+        out = node.outputs[index]
+        out.val = val
+
+    # Node.exec_output() =>
+    def exec_output(self, node, index):
+        for inp in self.graph[node.outputs[index]]:
+            inp.node.update(inp.node.inputs.index(inp))
+
+
+def executor_from_flow_alg(algorithm: FlowAlg):
+    if algorithm == FlowAlg.DATA:
+        return DataFlowNaive
+    if algorithm == FlowAlg.DATA_OPT:
+        return DataFlowOptimized
+    if algorithm == FlowAlg.EXEC:
+        return ExecFlowNaive

--- a/ryvencore/Node.py
+++ b/ryvencore/Node.py
@@ -381,7 +381,7 @@ class Node(Base):
         inp: NodeInput = self.inputs[index]
 
         # break all connections
-        for other in self.flow.graph_adjacency[inp]:
+        for other in self.flow.graph_adj_rev[inp]:
             self.flow.connect_nodes(other, inp)
 
         # for c in inp.connections:
@@ -412,7 +412,7 @@ class Node(Base):
         out: NodeOutput = self.outputs[index]
 
         # break all connections
-        for other in self.flow.graph_adjacency[out]:
+        for other in self.flow.graph_adj[out]:
             self.flow.connect_nodes(out, other)
 
         # for c in out.connections:
@@ -465,6 +465,9 @@ class Node(Base):
 
     def flow_in_data_opt_mode(self):
         return self.flow.alg_mode == FlowAlg.DATA_OPT
+
+    def inp_connected(self, index):
+        return self.flow.graph_adj_rev[self.inputs[index]] is not None
 
     """
     

--- a/ryvencore/Node.py
+++ b/ryvencore/Node.py
@@ -385,9 +385,6 @@ class Node(Base):
         if out is not None:
             self.flow.connect_nodes(out, inp)
 
-        # for c in inp.connections:
-        #     self.flow.connect_nodes(c.out, inp)
-
         self.inputs.remove(inp)
 
     def create_output(self, label: str = '', type_: str = 'data', insert: int = None):
@@ -415,9 +412,6 @@ class Node(Base):
         # break all connections
         for inp in self.flow.connected_inputs(out):
             self.flow.connect_nodes(out, inp)
-
-        # for c in out.connections:
-        #     self.flow.connect_nodes(out, c.inp)
 
         self.outputs.remove(out)
 

--- a/ryvencore/Node.py
+++ b/ryvencore/Node.py
@@ -381,8 +381,9 @@ class Node(Base):
         inp: NodeInput = self.inputs[index]
 
         # break all connections
-        for other in self.flow.graph_adj_rev[inp]:
-            self.flow.connect_nodes(other, inp)
+        out = self.flow.connected_output(inp)
+        if out is not None:
+            self.flow.connect_nodes(out, inp)
 
         # for c in inp.connections:
         #     self.flow.connect_nodes(c.out, inp)
@@ -412,8 +413,8 @@ class Node(Base):
         out: NodeOutput = self.outputs[index]
 
         # break all connections
-        for other in self.flow.graph_adj[out]:
-            self.flow.connect_nodes(out, other)
+        for inp in self.flow.connected_inputs(out):
+            self.flow.connect_nodes(out, inp)
 
         # for c in out.connections:
         #     self.flow.connect_nodes(out, c.inp)
@@ -467,7 +468,7 @@ class Node(Base):
         return self.flow.alg_mode == FlowAlg.DATA_OPT
 
     def inp_connected(self, index):
-        return self.flow.graph_adj_rev[self.inputs[index]] is not None
+        return self.flow.connected_output(self.inputs[index]) is not None
 
     """
     

--- a/ryvencore/Node.py
+++ b/ryvencore/Node.py
@@ -196,7 +196,10 @@ class Node(Base):
             try:
                 self.update_event(inp)
             except Exception as e:
-                InfoMsgs.write_err('EXCEPTION in', self.title, '\n', traceback.format_exc())
+                self.update_error(e)
+
+    def update_error(self, e):
+        InfoMsgs.write_err('EXCEPTION in', self.title, '\n', traceback.format_exc())
 
     def input(self, index: int):
         """Returns the value of a data input.

--- a/ryvencore/NodePort.py
+++ b/ryvencore/NodePort.py
@@ -12,24 +12,23 @@ class NodePort(Base):
     def __init__(self, node, io_pos, type_, label_str):
         Base.__init__(self)
 
-        self.val = None
         self.node = node
         self.io_pos = io_pos
         self.type_ = type_
         self.label_str = label_str
-        self.connections = []
+        # self.connections = []
 
-    def get_val(self):
-        pass
+    # def get_val(self):
+    #     pass
 
-    def connected(self):
-        pass
+    # def connected(self):
+    #     pass
 
-    def disconnected(self):
-        pass
+    # def disconnected(self):
+    #     pass
 
-    def flow_alg_data_mode(self):
-        return self.node.flow.alg_mode in (FlowAlg.DATA, FlowAlg.DATA_OPT)
+    # def flow_alg_data_mode(self):
+    #     return self.node.flow.alg_mode in (FlowAlg.DATA, FlowAlg.DATA_OPT)
 
     def data(self) -> dict:
         return {
@@ -50,39 +49,39 @@ class NodeInput(NodePort):
         # optional dtype
         self.dtype: DType = dtype
 
-    def connected(self):
-        super().connected()
-        if self.type_ == 'data':
-            self.val = self.connections[0].get_val()
-            if self.flow_alg_data_mode():
-                self.node.update(self.node.inputs.index(self))
+    # def connected(self):
+    #     super().connected()
+    #     if self.type_ == 'data':
+    #         self.val = self.connections[0].get_val()
+    #         if self.flow_alg_data_mode():
+    #             self.node.update(self.node.inputs.index(self))
 
-    def disconnected(self):
-        super().disconnected()
-        if self.type_ == 'data' and self.flow_alg_data_mode():
-            self.node.update(self.node.inputs.index(self))
+    # def disconnected(self):
+    #     super().disconnected()
+    #     if self.type_ == 'data' and self.flow_alg_data_mode():
+    #         self.node.update(self.node.inputs.index(self))
 
-    def get_val(self):
-        InfoMsgs.write('getting value of node input')
+    # def get_val(self):
+    #     InfoMsgs.write('getting value of node input')
+    #
+    #     if self.flow_alg_data_mode() or len(self.connections) == 0:
+    #         return self.val
+    #     else:  # len(self.connections) > 0:
+    #         return self.connections[0].get_val()
 
-        if self.flow_alg_data_mode() or len(self.connections) == 0:
-            return self.val
-        else:  # len(self.connections) > 0:
-            return self.connections[0].get_val()
-
-    def update(self, data=None):
-        """called from another node or from connected()"""
-        if self.type_ == 'data':
-            self.val = data  # self.get_val()
-            InfoMsgs.write('Data in input set to', data)
-
-        self.node.update(inp=self.node.inputs.index(self))
+    # def update(self, data=None):
+    #     """called from another node or from connected()"""
+    #     if self.type_ == 'data':
+    #         self.val = data  # self.get_val()
+    #         InfoMsgs.write('Data in input set to', data)
+    #
+    #     self.node.update(inp=self.node.inputs.index(self))
 
     def data(self) -> dict:
         data = super().data()
 
-        if len(self.connections) == 0:
-            data['val'] = serialize(self.get_val())
+        # if len(self.connections) == 0:
+        #     data['val'] = serialize(self.get_val())
 
         if self.dtype:
             data['dtype'] = str(self.dtype)
@@ -96,26 +95,28 @@ class NodeOutput(NodePort):
     def __init__(self, node, type_, label_str=''):
         super().__init__(node, PortObjPos.OUTPUT, type_, label_str)
 
-    def exec(self):
-        for c in self.connections:
-            c.activate()
+        self.val = None
 
-    def get_val(self):
-        InfoMsgs.write('getting value in node output')
+    # def exec(self):
+    #     for c in self.connections:
+    #         c.activate()
 
-        if self.node.flow.alg_mode == FlowAlg.EXEC:
-            self.node.update()
+    # def get_val(self):
+    #     InfoMsgs.write('getting value in node output')
+    #
+    #     if self.node.flow.alg_mode == FlowAlg.EXEC:
+    #         self.node.update()
+    #
+    #     return self.val
 
-        return self.val
-
-    def set_val(self, val):
-        InfoMsgs.write('setting value in node output')
-
-        self.val = val
-
-        if self.flow_alg_data_mode():
-            for c in self.connections:
-                c.activate(data=val)
+    # def set_val(self, val):
+    #     InfoMsgs.write('setting value in node output')
+    #
+    #     self.val = val
+    #
+    #     if self.flow_alg_data_mode():
+    #         for c in self.connections:
+    #             c.activate(data=val)
 
     # def connected(self):
     #     super().connected()

--- a/ryvencore/NodePort.py
+++ b/ryvencore/NodePort.py
@@ -16,19 +16,6 @@ class NodePort(Base):
         self.io_pos = io_pos
         self.type_ = type_
         self.label_str = label_str
-        # self.connections = []
-
-    # def get_val(self):
-    #     pass
-
-    # def connected(self):
-    #     pass
-
-    # def disconnected(self):
-    #     pass
-
-    # def flow_alg_data_mode(self):
-    #     return self.node.flow.alg_mode in (FlowAlg.DATA, FlowAlg.DATA_OPT)
 
     def data(self) -> dict:
         return {
@@ -49,39 +36,8 @@ class NodeInput(NodePort):
         # optional dtype
         self.dtype: DType = dtype
 
-    # def connected(self):
-    #     super().connected()
-    #     if self.type_ == 'data':
-    #         self.val = self.connections[0].get_val()
-    #         if self.flow_alg_data_mode():
-    #             self.node.update(self.node.inputs.index(self))
-
-    # def disconnected(self):
-    #     super().disconnected()
-    #     if self.type_ == 'data' and self.flow_alg_data_mode():
-    #         self.node.update(self.node.inputs.index(self))
-
-    # def get_val(self):
-    #     InfoMsgs.write('getting value of node input')
-    #
-    #     if self.flow_alg_data_mode() or len(self.connections) == 0:
-    #         return self.val
-    #     else:  # len(self.connections) > 0:
-    #         return self.connections[0].get_val()
-
-    # def update(self, data=None):
-    #     """called from another node or from connected()"""
-    #     if self.type_ == 'data':
-    #         self.val = data  # self.get_val()
-    #         InfoMsgs.write('Data in input set to', data)
-    #
-    #     self.node.update(inp=self.node.inputs.index(self))
-
     def data(self) -> dict:
         data = super().data()
-
-        # if len(self.connections) == 0:
-        #     data['val'] = serialize(self.get_val())
 
         if self.dtype:
             data['dtype'] = str(self.dtype)
@@ -96,29 +52,3 @@ class NodeOutput(NodePort):
         super().__init__(node, PortObjPos.OUTPUT, type_, label_str)
 
         self.val = None
-
-    # def exec(self):
-    #     for c in self.connections:
-    #         c.activate()
-
-    # def get_val(self):
-    #     InfoMsgs.write('getting value in node output')
-    #
-    #     if self.node.flow.alg_mode == FlowAlg.EXEC:
-    #         self.node.update()
-    #
-    #     return self.val
-
-    # def set_val(self, val):
-    #     InfoMsgs.write('setting value in node output')
-    #
-    #     self.val = val
-    #
-    #     if self.flow_alg_data_mode():
-    #         for c in self.connections:
-    #             c.activate(data=val)
-
-    # def connected(self):
-    #     super().connected()
-    #     if self.type_ == 'data' and self.node.flow.alg_mode == FlowAlg.DATA:
-    #         self.set_val(self.val)  # update output

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ryvencore
-version = v0.3.1.1
+version = v0.4.0a1
 author = Leon Thomm
 author_email = l.thomm@mailbox.org
 description = Python backend for node editor-like graph-based processing

--- a/setup_cython.py
+++ b/setup_cython.py
@@ -8,9 +8,9 @@ $ pip uninstall ryvencore
 The below instructions show how to compile the sources on your system. Note that you will need Cython and an according
 C compiler for this.
 
-$ python -m setup_cython build_ext --inplace
-$ python setup_cython.py sdist bdist_wheel
-$ pip install ./dist/ryvencore-<version>-<platform>.whl
+    $ python -m setup_cython build_ext --inplace
+    $ python setup_cython.py sdist bdist_wheel
+    $ pip install ./dist/ryvencore-<version>-<platform>.whl
 
 NOTE
 -   if you don't want to keep the source files (.py and compiled .c) in the installed package (only the compiled .so
@@ -18,10 +18,15 @@ NOTE
 
 To verify that the package successfully runs from the compiled C extension modules you can check whether
 the imported ryvencore package shows the __init__.so file and not __init__.py
-> import ryvencore as rc
-> print(rc)
+
+    $ python
+    > import ryvencore as rc
+    > print(rc)
+
 and to really be sure you can also manually remove all .py files in the installation directory
-(on linux: $ .../site-packages/ryvencore>find . -name "*.py" -type f -delete)
+
+    on Linux: $ .../site-packages/ryvencore> find . -name "*.py" -type f -delete
+
 and check whether you can successfully load the package from Python.
 """
 

--- a/setup_cython.py
+++ b/setup_cython.py
@@ -27,7 +27,7 @@ and check whether you can successfully load the package from Python.
 
 
 from setuptools import setup
-from Cython.Build import cythonize
+from Cython.Build import cythonize, build_ext
 import os
 
 
@@ -53,8 +53,10 @@ def get_ext_paths(root_dir, exclude_files=[], recursive=True):
 
 
 setup(
+    cmaclass={'build_ext': build_ext},
     ext_modules=cythonize(
         get_ext_paths('ryvencore'),
-        compiler_directives={'language_level': 3}
+        compiler_directives={'language_level': 3},
+        annotate=True,
     )
 )

--- a/setup_cython.py
+++ b/setup_cython.py
@@ -1,28 +1,27 @@
 """
 This setup file can be used to manually compile ryvencore to a C extension using Cython, behavior should be the same.
 
-COMPILE INSTRUCTIONS
+HOW TO COMPILE
 
 Run all commands from the top level 'ryvencore' directory, and remember to remove any old ryvencore version initially
 $ pip uninstall ryvencore
 The below instructions show how to compile the sources on your system. Note that you will need Cython and an according
 C compiler for this.
 
-    COMPILE EVERY SINGLE MODULE
-
 $ python -m setup_cython build_ext --inplace
 $ python setup_cython.py sdist bdist_wheel
 $ pip install ./dist/ryvencore-<version>-<platform>.whl
 
-NOTE: if you don't want to keep the source files (.py and compiled .c) in the installed package
-(only the compiled .so files), simply comment out the line
-packages = find:
-in setup.cfg.
+NOTE
+-   if you don't want to keep the source files (.py and compiled .c) in the installed package (only the compiled .so
+    files), simply comment out the line `packages = find:` in setup.cfg
 
-To verify that the package successfully runs from the compiled c extension modules you can check whether
-the imported ryvencore package shows the __init__.so file and not __init__.py, and you can manually remove
-all .py files in the installation directory
-(on linux: `.../site-packages/ryvencore>find . -name "*.py" -type f -delete`)
+To verify that the package successfully runs from the compiled C extension modules you can check whether
+the imported ryvencore package shows the __init__.so file and not __init__.py
+> import ryvencore as rc
+> print(rc)
+and to really be sure you can also manually remove all .py files in the installation directory
+(on linux: $ .../site-packages/ryvencore>find . -name "*.py" -type f -delete)
 and check whether you can successfully load the package from Python.
 """
 
@@ -55,6 +54,7 @@ def get_ext_paths(root_dir, exclude_files=[], recursive=True):
 
 setup(
     ext_modules=cythonize(
-        get_ext_paths('ryvencore')
+        get_ext_paths('ryvencore'),
+        compiler_directives={'language_level': 3}
     )
 )

--- a/setup_cython.py
+++ b/setup_cython.py
@@ -1,15 +1,23 @@
 """
 This setup file can be used to manually compile ryvencore to a C extension using Cython, behavior should be the same.
-To compile ryvencore from sources on your system, from the top level 'ryvencore' directory run:
+
+COMPILE INSTRUCTIONS
+
+Run all commands from the top level 'ryvencore' directory, and remember to remove any old ryvencore version initially
+$ pip uninstall ryvencore
+The below instructions show how to compile the sources on your system. Note that you will need Cython and an according
+C compiler for this.
+
+    COMPILE EVERY SINGLE MODULE
 
 $ python -m setup_cython build_ext --inplace
 $ python setup_cython.py sdist bdist_wheel
 $ pip install ./dist/ryvencore-<version>-<platform>.whl
 
-remember to remove any old ryvencore version before
-$ pip uninstall ryvencore
-
-This will compile the sources on your system. note that you will need Cython and an according C compiler.
+NOTE: if you don't want to keep the source files (.py and compiled .c) in the installed package
+(only the compiled .so files), simply comment out the line
+packages = find:
+in setup.cfg.
 
 To verify that the package successfully runs from the compiled c extension modules you can check whether
 the imported ryvencore package shows the __init__.so file and not __init__.py, and you can manually remove

--- a/setup_cython.py
+++ b/setup_cython.py
@@ -1,0 +1,44 @@
+"""
+This setup file can be used to manually compile ryvencore to a C extension using Cython, behavior should be the same.
+To compile ryvencore from sources on your system, from the top level 'ryvencore' directory run:
+$ python -m setup_cython sdist
+$ pip install ./dist/ryvencore-<version>.tar.gz
+
+remember to remove any old ryvencore version before
+$ pip uninstall ryvencore
+
+this will compile the sources on your system. note that you will need Cython and an according C compiler.
+"""
+
+
+from setuptools import setup
+from Cython.Build import cythonize
+import os
+
+
+def get_ext_paths(root_dir, exclude_files=[], recursive=True):
+    """get filepaths for compilation"""
+    paths = []
+
+    for root, dirs, files in os.walk(root_dir):
+        for filename in files:
+            if os.path.splitext(filename)[1] != '.py':
+                continue
+
+            file_path = os.path.join(root, filename)
+            if file_path in exclude_files:
+                continue
+
+            paths.append(file_path)
+
+        if recursive:
+            for d in dirs:
+                paths += get_ext_paths(d, exclude_files)
+    return paths
+
+
+setup(
+    ext_modules=cythonize(
+        get_ext_paths('ryvencore')
+    )
+)

--- a/setup_cython.py
+++ b/setup_cython.py
@@ -1,13 +1,21 @@
 """
 This setup file can be used to manually compile ryvencore to a C extension using Cython, behavior should be the same.
 To compile ryvencore from sources on your system, from the top level 'ryvencore' directory run:
-$ python -m setup_cython sdist
-$ pip install ./dist/ryvencore-<version>.tar.gz
+
+$ python -m setup_cython build_ext --inplace
+$ python setup_cython.py sdist bdist_wheel
+$ pip install ./dist/ryvencore-<version>-<platform>.whl
 
 remember to remove any old ryvencore version before
 $ pip uninstall ryvencore
 
-this will compile the sources on your system. note that you will need Cython and an according C compiler.
+This will compile the sources on your system. note that you will need Cython and an according C compiler.
+
+To verify that the package successfully runs from the compiled c extension modules you can check whether
+the imported ryvencore package shows the __init__.so file and not __init__.py, and you can manually remove
+all .py files in the installation directory
+(on linux: `.../site-packages/ryvencore>find . -name "*.py" -type f -delete`)
+and check whether you can successfully load the package from Python.
 """
 
 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,93 @@
+import unittest
+import ryvencore as rc
+
+
+class DataFlowBasic(unittest.TestCase):
+
+    class Node1(rc.Node):
+        title = 'node 1'
+        init_inputs = []
+        init_outputs = [rc.NodeOutputBP(type_='data'), rc.NodeOutputBP(type_='data')]
+
+        def update_event(self, inp=-1):
+            self.set_output_val(0, 'Hello, World!')
+            self.set_output_val(1, 42)
+            print('finished')
+
+    class Node2(rc.Node):
+        title = 'node 2'
+        init_inputs = [rc.NodeInputBP('data')]
+        init_outputs = []
+
+        def update_event(self, inp=-1):
+            print(f'received data on input {inp}: {self.input(inp)}')
+
+    def runTest(self):
+        s = rc.Session()
+        f = s.create_script('main').flow
+
+        n1 = f.create_node(self.Node1)
+        n2 = f.create_node(self.Node2)
+        n3 = f.create_node(self.Node2)
+
+        f.connect_nodes(n1.outputs[0], n2.inputs[0])
+        f.connect_nodes(n1.outputs[1], n3.inputs[0])
+
+        self.assertEqual(n1.outputs[0].val, None)
+        self.assertEqual(n1.outputs[1].val, None)
+
+        n1.update()
+
+        self.assertEqual(n1.outputs[0].val, 'Hello, World!')
+        self.assertEqual(n1.outputs[1].val, 42)
+
+
+class ExecFlowBasic(unittest.TestCase):
+
+    class Node1(rc.Node):
+        title = 'node 1'
+        init_inputs = []
+        init_outputs = [rc.NodeOutputBP(type_='exec'), rc.NodeOutputBP(type_='data')]
+
+        def update_event(self, inp=-1):
+            self.set_output_val(1, 'Hello, World!')
+            self.exec_output(0)
+            print('finished')
+
+    class Node2(rc.Node):
+        title = 'node 2'
+        init_inputs = [rc.NodeInputBP(type_='exec'), rc.NodeInputBP(type_='data')]
+        init_outputs = []
+
+        def __init__(self, params):
+            super().__init__(params)
+
+            self.data = None
+
+        def update_event(self, inp=-1):
+            self.data = self.input(1)
+            print(f'received data on input {inp}: {self.input(inp)}')
+
+
+    def runTest(self):
+        s = rc.Session()
+        f = s.create_script('main').flow
+        f.set_algorithm_mode('exec')
+
+        n1 = f.create_node(self.Node1)
+        n2 = f.create_node(self.Node2)
+        n3 = f.create_node(self.Node2)
+
+        f.connect_nodes(n1.outputs[0], n2.inputs[0])
+        f.connect_nodes(n1.outputs[1], n2.inputs[1])
+        f.connect_nodes(n1.outputs[0], n3.inputs[0])
+        # f.connect_nodes(n1.outputs[1], n3.inputs[1])
+
+        self.assertEqual(n1.outputs[0].val, None)
+        self.assertEqual(n1.outputs[1].val, None)
+
+        n1.update()
+
+        self.assertEqual(n1.outputs[1].val, 'Hello, World!')
+        self.assertEqual(n2.data, 'Hello, World!')
+        self.assertEqual(n3.data, None)


### PR DESCRIPTION
Reimplements flow execution:

- now fully centralized via `FlowExecutor` classes
- not determined by a (confusing) set of cooperating methods in `Node`, `Connection`, and `NodePort` anymore
- removed `Connection`, the graph now stores everything adjacency list-style with various optimizations