### PR TITLE
add-on improvements

### DIFF
--- a/ryvencore/AddOn.py
+++ b/ryvencore/AddOn.py
@@ -74,7 +74,7 @@ class AddOn(Base):
     #     """
     #     pass
 
-    def on_node_added(self, flow, node):
+    def on_node_added(self, node):
         """
         *VIRTUAL*
 

--- a/ryvencore/AddOn.py
+++ b/ryvencore/AddOn.py
@@ -26,7 +26,7 @@ To define a custom add-on:
 
 See :code:`ryvencore.addons.default` for examples.
 """
-
+from ryvencore import Flow
 from ryvencore.Base import Base
 
 
@@ -40,33 +40,49 @@ class AddOn(Base):
         """
         self.session = session
 
-    def _on_node_created(self, flow, node):
+    def connect_flow_events(self, flow: Flow):
+        """
+        Connects flow events to the add-on.
+        """
+        flow.node_added.connect(self.on_node_added)
+        flow.node_removed.connect(self.on_node_removed)
+
+    def on_flow_created(self, flow):
         """
         *VIRTUAL*
 
-        Called when a node is created. This happens only once, whereas
-        a node can be added and removed multiple times, see
-        on_node_added() and
-        on_node_removed().
+        Called when a flow is created.
         """
         pass
 
-    def _on_node_added(self, flow, node):
+    def on_flow_destroyed(self, flow):
         """
         *VIRTUAL*
 
-        Called when a node is added to a flow. Notice, however, that currently
-        add-ons are loaded after nodes, so in case you are storing some state
-        and you need to rebuild any sort of connections between nodes and your
-        add-on during loading, this function will be called *before* the
-        add-on itself is loaded, so you might want to shift this logic
-        into :code:`set_state()` at which point all nodes will be initialized.
-        
-        **This might change.**
+        Called when a flow is destroyed.
         """
         pass
 
-    def _on_node_removed(self, flow, node):
+    # def on_node_created(self, flow, node):
+    #     """
+    #     *VIRTUAL*
+    #
+    #     Called when a node is created. This happens only once, whereas
+    #     a node can be added and removed multiple times, see
+    #     on_node_added() and
+    #     on_node_removed().
+    #     """
+    #     pass
+
+    def on_node_added(self, flow, node):
+        """
+        *VIRTUAL*
+
+        Called when a node is added to a flow.
+        """
+        pass
+
+    def on_node_removed(self, flow, node):
         """
         *VIRTUAL*
 
@@ -74,11 +90,13 @@ class AddOn(Base):
         """
         pass
 
-    def _extend_node_data(self, node, data: dict):
+    def extend_node_data(self, node, data: dict):
         """
         *VIRTUAL*
 
-        Extend the node data dict with additional add-on-related data.
+        Invoked whenever any node is serialized. This method can be
+        used to extend the node's data dict with additional
+        add-on.related data.
         """
         pass
 
@@ -96,7 +114,11 @@ class AddOn(Base):
         *VIRTUAL*
 
         Set the state of the add-on from the dict generated in
-        :code:`AddOn.get_state()`.
+        :code:`AddOn.get_state()`. Notice that add-ons are loaded
+        *before* the flows. If you need to re-establish any sort
+        of connections between flows or nodes and your add-on,
+        you should store :code:`state` and do so in the according
+        slot methods (e.g. :code:`on_node_added()`).
         """
         pass
 

--- a/ryvencore/AddOn.py
+++ b/ryvencore/AddOn.py
@@ -64,7 +64,7 @@ class AddOn(Base):
         """
         pass
 
-    def on_node_created(self, flow, node):
+    def on_node_created(self, node):
         """
         *VIRTUAL*
 

--- a/ryvencore/AddOn.py
+++ b/ryvencore/AddOn.py
@@ -8,23 +8,23 @@ can be added and registered in the Session.
 An add-on
     - has a name and a version
     - is session-local, not flow-local (but you can of course implement per-flow functionality)
-    - manages its own state (in particular ``get_state()`` and ``set_state()``)
-    - can store additional node-specific data in the node's ``data`` dict when it's serialized
-    - will be accessible through the nodes API: ``self.get_addon('your_addon')`` in your nodes
+    - manages its own state (in particular :code:`get_state()` and :code:`set_state()`)
+    - can store additional node-specific data in the node's :code:`data` dict when it's serialized
+    - will be accessible through the nodes API: :code:`self.get_addon('your_addon')` in your nodes
 
 Add-on access is blocked during loading (deserialization), so nodes should not access any
-add-ons during the execution of ``Node.__init__`` or ``Node.set_data``.
+add-ons during the execution of :code:`Node.__init__` or :code:`Node.set_data`.
 This prevents inconsistent states. Nodes are loaded first, then the add-ons. 
 Therefore, the add-on should be sufficiently isolated and self-contained.
 
 To define a custom add-on:
-    - create a directory ``your_addons`` for you addons or use ryvencore's addon directory
-    - create a module for your addon ``YourAddon.py`` in ``your_addons``
-    - create a class ``YourAddon(ryvencore.AddOn)`` that defines your add-on's functionality
-    - instantiate it into a top-level variable: ``addon = YourAddon()`` at the end of the module
-    - register your addon directory in the Session: ``session.register_addon_dir('path/to/your_addons')``
+    - create a directory :code:`your_addons` for you addons or use ryvencore's addon directory
+    - create a module for your addon :code:`YourAddon.py` in :code:`your_addons`
+    - create a class :code:`YourAddon(ryvencore.AddOn)` that defines your add-on's functionality
+    - instantiate it into a top-level variable: :code:`addon = YourAddon()` at the end of the module
+    - register your addon directory in the Session: :code:`session.register_addon_dir('path/to/your_addons')`
 
-See ``ryvencore.addons.default`` for examples.
+See :code:`ryvencore.addons.default` for examples.
 """
 
 from ryvencore.Base import Base
@@ -55,7 +55,14 @@ class AddOn(Base):
         """
         *VIRTUAL*
 
-        Called when a node is added to a flow.
+        Called when a node is added to a flow. Notice, however, that currently
+        add-ons are loaded after nodes, so in case you are storing some state
+        and you need to rebuild any sort of connections between nodes and your
+        add-on during loading, this function will be called *before* the
+        add-on itself is loaded, so you might want to shift this logic
+        into :code:`set_state()` at which point all nodes will be initialized.
+        
+        **This might change.**
         """
         pass
 

--- a/ryvencore/AddOn.py
+++ b/ryvencore/AddOn.py
@@ -44,6 +44,7 @@ class AddOn(Base):
         """
         Connects flow events to the add-on.
         """
+        flow.node_created.connect(self.on_node_created)
         flow.node_added.connect(self.on_node_added)
         flow.node_removed.connect(self.on_node_removed)
 
@@ -63,16 +64,20 @@ class AddOn(Base):
         """
         pass
 
-    # def on_node_created(self, flow, node):
-    #     """
-    #     *VIRTUAL*
-    #
-    #     Called when a node is created. This happens only once, whereas
-    #     a node can be added and removed multiple times, see
-    #     on_node_added() and
-    #     on_node_removed().
-    #     """
-    #     pass
+    def on_node_created(self, flow, node):
+        """
+        *VIRTUAL*
+
+        Called when a node is created and fully initialized
+        (:code:`Node.load()` has already been called, if necessary),
+        but not yet added to the flow. Therefore, this is a good place
+        to initialize the node with add-on-specific data.
+
+        This happens only once per node, whereas it can be added and
+        removed multiple times, see :code:`AddOn.on_node_added()` and
+        :code:`AddOn.on_node_removed()`.
+        """
+        pass
 
     def on_node_added(self, node):
         """

--- a/ryvencore/Base.py
+++ b/ryvencore/Base.py
@@ -133,7 +133,16 @@ class Base:
     def load(self, data: dict):
         """
         Recreate the object state from the data dict returned by :code:`data()`.
+
+        Convention: don't call this method in the constructor, invoke it manually
+        from outside, if other components can depend on it (and be notified of its
+        creation).
+        Reason: If another component `X` depends on this one (and
+        gets notified when this one is created), `X` should be notified *before*
+        it gets notified of creation or loading of subcomponents created during
+        this load. (E.g. add-ons need to know the flow before nodes are loaded.)
         """
+
         if dict is not None:
             self.prev_global_id = data['GID']
             self._prev_id_objs[self.prev_global_id] = self

--- a/ryvencore/Flow.py
+++ b/ryvencore/Flow.py
@@ -203,8 +203,9 @@ class Flow(Base):
             print_err(f'Node class {node_class} not in session nodes')
             return
 
-        node = node_class((self, self.session, data))
-        node.initialize()
+        node = node_class((self, self.session))
+        if data is not None:
+            node.load(data)
         self.add_node(node)
 
         return node

--- a/ryvencore/Flow.py
+++ b/ryvencore/Flow.py
@@ -111,7 +111,7 @@ class Flow(Base):
         # events
         self.node_added = Event(Node)
         self.node_removed = Event(Node)
-        self.node_created = Event((Node, dict))
+        self.node_created = Event(Node)
         self.connection_added = Event((NodeOutput, NodeInput))        # Event(Connection)
         self.connection_removed = Event((NodeOutput, NodeInput))      # Event (Connection)
 
@@ -207,7 +207,7 @@ class Flow(Base):
         node = node_class((self, self.session))
         if data is not None:
             node.load(data)
-        self.node_created.emit(node, data)
+        self.node_created.emit(node)
         self.add_node(node)
 
         return node

--- a/ryvencore/Flow.py
+++ b/ryvencore/Flow.py
@@ -250,7 +250,7 @@ class Flow(Base):
 
         # notify addons
         for addon in self.session.addons.values():
-            addon._on_node_removed(self, node)
+            addon.on_node_removed(self, node)
 
         self.node_removed.emit(node)
 

--- a/ryvencore/Flow.py
+++ b/ryvencore/Flow.py
@@ -120,6 +120,10 @@ class Flow(Base):
 
         self.algorithm_mode_changed = Event(str)
 
+        # connect events to add-ons
+        for addon in session.addons.values():
+            addon.connect_flow_events(self)
+
         # general attributes
         self.session = session
         self.title = title
@@ -203,10 +207,6 @@ class Flow(Base):
         node.initialize()
         self.add_node(node)
 
-        # notify addons
-        for addon in self.session.addons.values():
-            addon._on_node_created(self, node)
-
         return node
 
 
@@ -227,10 +227,6 @@ class Flow(Base):
 
         node.after_placement()
         self._flow_changed()
-
-        # notify addons
-        for addon in self.session.addons.values():
-            addon._on_node_added(self, node)
 
         self.node_added.emit(node)
 

--- a/ryvencore/Flow.py
+++ b/ryvencore/Flow.py
@@ -111,6 +111,7 @@ class Flow(Base):
         # events
         self.node_added = Event(Node)
         self.node_removed = Event(Node)
+        self.node_created = Event((Node, dict))
         self.connection_added = Event((NodeOutput, NodeInput))        # Event(Connection)
         self.connection_removed = Event((NodeOutput, NodeInput))      # Event (Connection)
 
@@ -206,6 +207,7 @@ class Flow(Base):
         node = node_class((self, self.session))
         if data is not None:
             node.load(data)
+        self.node_created.emit(node, data)
         self.add_node(node)
 
         return node

--- a/ryvencore/Node.py
+++ b/ryvencore/Node.py
@@ -433,6 +433,6 @@ class Node(Base):
         # extend with data from addons
         for name, addon in self.session.addons.items():
             # addons can modify anything, there is no isolation enforcement
-            addon._extend_node_data(self, d)
+            addon.extend_node_data(self, d)
 
         return d

--- a/ryvencore/Node.py
+++ b/ryvencore/Node.py
@@ -257,6 +257,8 @@ class Node(Base):
         *VIRTUAL*
 
         Opposite of ``get_state()``, reconstruct any custom internal state here.
+        Notice, that add-ons might not yet be fully available here, but in
+        ``place_event()`` the should be.
         """
         pass
 

--- a/ryvencore/Session.py
+++ b/ryvencore/Session.py
@@ -38,14 +38,16 @@ class Session(Base):
         self.gui: bool = gui
         self.init_data = None
 
-        self.load_addons(pkg_path('addons/default/'))
-        self.load_addons(pkg_path('addons/'))
+        self.register_addons(pkg_path('addons/default/'))
+        self.register_addons(pkg_path('addons/'))
 
 
-    def load_addons(self, location: str):
+    def register_addons(self, location: str):
         """
-        Loads all addons from the given location. ``location`` can be an absolute path to any readable directory.
-        See ``ryvencore.AddOn``.
+        Loads all addons from the given location. :code:`location` can
+        be an absolute path to any readable directory. New addons can be
+        registered at any time.
+        See :code:`ryvencore.AddOn`.
         """
 
         # discover all top-level modules in the given location

--- a/ryvencore/Session.py
+++ b/ryvencore/Session.py
@@ -146,8 +146,6 @@ class Session(Base):
         if data:
             flow.load(data)
 
-        self.new_flow_created.emit(flow)
-
         return flow
 
 

--- a/ryvencore/addons/default/DTypes.py
+++ b/ryvencore/addons/default/DTypes.py
@@ -211,18 +211,18 @@ class DtypesAddon(AddOn):
 
         self.dtype_inputs[inp] = dtype
 
-    def _on_node_created(self, flow, node):
+    def on_node_created(self, flow, node):
         """
         Restores the node's dtypes.
         """
 
         for i, inp in enumerate(node.inputs):
-            if inp.type_ == 'data' and 'dtype' in node.init_data['inputs'][i]:
-                dtype = DType.from_str(node.init_data['inputs'][i]['dtype'])
-                dtype.set_state(node.init_data['inputs'][i]['dtype']['state'])
+            if inp.type_ == 'data' and 'dtype' in node.load_data['inputs'][i]:
+                dtype = DType.from_str(node.load_data['inputs'][i]['dtype'])
+                dtype.set_state(node.load_data['inputs'][i]['dtype']['state'])
                 self.dtype_inputs[inp] = dtype
 
-    def _extend_node_data(self, node, data: dict):
+    def extend_node_data(self, node, data: dict):
         for i, inp in enumerate(node.inputs):
             if inp in self.dtype_inputs:
                 data['inputs'][i]['dtype'] = {

--- a/ryvencore/addons/default/Logging.py
+++ b/ryvencore/addons/default/Logging.py
@@ -70,9 +70,9 @@ class LoggingAddon(AddOn):
         # self.logger_created.emit(logger)
         return logger
 
-    def _on_node_created(self, flow, node):
-        if node.init_data and 'Logging' in node.init_data:
-            for title in node.init_data['Logging']['loggers']:
+    def on_node_created(self, flow, node):
+        if node.load_data and 'Logging' in node.load_data:
+            for title in node.load_data['Logging']['loggers']:
                 self.new_logger(node, title)
                 # in case the node already created the logger,
                 # new_logger() will have no effect
@@ -80,7 +80,7 @@ class LoggingAddon(AddOn):
     def _node_is_registered(self, node):
         return node in self.loggers
 
-    def _on_node_added(self, flow, node):
+    def on_node_added(self, node):
         if not self._node_is_registered(node):
             return
 
@@ -88,7 +88,7 @@ class LoggingAddon(AddOn):
         for logger in self.loggers[node].values():
             logger.enable()
 
-    def _on_node_removed(self, flow, node):
+    def on_node_removed(self, flow, node):
         if not self._node_is_registered(node):
             return
 
@@ -96,7 +96,7 @@ class LoggingAddon(AddOn):
         for logger in self.loggers[node].values():
             logger.disable()
 
-    def _extend_node_data(self, node, data: dict):
+    def extend_node_data(self, node, data: dict):
         if not self._node_is_registered(node):
             return
 
@@ -104,4 +104,4 @@ class LoggingAddon(AddOn):
             'loggers': [name for name in self.loggers[node].keys()]
         }
 
-addon = LoggingAddon()
+# addon = LoggingAddon()

--- a/ryvencore/addons/default/Logging.py
+++ b/ryvencore/addons/default/Logging.py
@@ -27,10 +27,10 @@ class Logger(PyLogger):
 
 class LoggingAddon(AddOn):
     """
-    This addon implements very basic some logging functionality.
+    This addon implements some very basic logging functionality.
 
-    It provides an API to create and delete loggers that are owned
-    by a particular node. The logger gets enabled/disabled
+    It provides functions to create and delete loggers that are owned
+    by a particular node. The loggers get enabled/disabled
     automatically when the owning node is added to/removed from
     the flow.
 
@@ -38,7 +38,7 @@ class LoggingAddon(AddOn):
     preserves its global ID throughout save and load.
 
     The contents of logs are currently not preserved. If a log's
-    content should be preserved, it should be saved in a file.
+    content should be preserved, it should be saved explicitly.
 
     Refer to Python's logging module documentation.
     """
@@ -70,7 +70,7 @@ class LoggingAddon(AddOn):
         # self.logger_created.emit(logger)
         return logger
 
-    def on_node_created(self, flow, node):
+    def on_node_created(self, node):
         if node.load_data and 'Logging' in node.load_data:
             for title in node.load_data['Logging']['loggers']:
                 self.new_logger(node, title)
@@ -104,4 +104,4 @@ class LoggingAddon(AddOn):
             'loggers': [name for name in self.loggers[node].keys()]
         }
 
-# addon = LoggingAddon()
+addon = LoggingAddon()

--- a/ryvencore/addons/default/Variables.py
+++ b/ryvencore/addons/default/Variables.py
@@ -137,7 +137,8 @@ class VarsAddon(AddOn):
     subscription management
     """
 
-    def on_node_created(self, flow, node):
+    def on_node_created(self, node):
+        flow = node.flow
 
         # is invoked *before* the node is added to the flow
 

--- a/tests/logging-addon.py
+++ b/tests/logging-addon.py
@@ -2,7 +2,7 @@ import unittest
 import ryvencore as rc
 from utils import check_addon_available
 
-# check_addon_available('Logging', __file__)
+check_addon_available('Logging', __file__)
 
 from ryvencore.addons.default.Logging import addon as Logging
 

--- a/tests/variables-addon.py
+++ b/tests/variables-addon.py
@@ -61,7 +61,7 @@ class Node2(NodeBase):
         print('var1 successfully updated:', val)
 
 
-class DataFlowBasic(unittest.TestCase):
+class VariablesBasic(unittest.TestCase):
 
     def runTest(self):
         s = rc.Session()


### PR DESCRIPTION
It is not immediately clear to me what the order of loading should be, whether add-ons should be loaded before flows, or the other way around.

**add-ons first**

- the add-on cannot re-establish shared state between itself and nodes in `set_state()` because the nodes don't exist yet
- add-on might have to store the loading data and pay close attention to nodes being created and re-establish state when the respective node is built
- identification of nodes for the above is easy with `prev_global_id`
- nodes have full access to initialized addon in `place_event()`
- might have the advantage that establishing connections with *duplicated* components does not require extra work in the add-on

more work for add-on dev, less work for nodes dev

**flows first**

- the add-on can re-establish full state on `set_state()` because nodes exist already
- no complex keeping track of created nodes
- nodes do not have access to add-on related data and API in `place_event()`, and they don't know when it will be available, because the whole loading process must be finished before any add-ons are initialized

more work for nodes dev, less work for add-on dev

***

I previously implemented the latter approach, but I think I should try switching, as I would personally prefer keeping nodes as simple as possible.