### PR TITLE
Fix all_node_objects

### DIFF
--- a/ryvencore/Session.py
+++ b/ryvencore/Session.py
@@ -112,7 +112,7 @@ class Session(Base):
 
         nodes = []
         for s in self.flows:
-            for n in s.flow.nodes:
+            for n in s.nodes:
                 nodes.append(n)
         return nodes
 


### PR DESCRIPTION
This fixes an issue I think has escaped your attention when removing the script objects. I think it is only used by the Save feature in Ryven.