### PR TITLE
Multiple Outputs to Single Input - Connection Validity

### DIFF
--- a/ryvencore/Node.py
+++ b/ryvencore/Node.py
@@ -163,16 +163,29 @@ class Node(Base):
         InfoMsgs.write_err('EXCEPTION in', self.title, '\n', traceback.format_exc())
         self.update_error.emit(e)
 
-    def input(self, index: int) -> Optional[Data]:
+    def input_value(self, index: int) -> Optional[Data]:
         """
-        Returns the data residing at the data input of given index.
+        Returns the data residing at the first input of given index. This is 
+        essentially the value at the first connection made to this input.
 
         Do not call on exec inputs.
         """
 
-        InfoMsgs.write('input called in', self.title, ':', index)
+        InfoMsgs.write('first input called in', self.title, ':', index)
 
-        return self.flow.executor.input(self, index)
+        return self.flow.executor.input_value(self, index)
+    
+    def input_values(self, index: int) -> Optional[List[Data]]:
+        """
+        Returns a new list of data for all connections to this input.
+        Ordered from first connection made to last
+        
+        Do not call on exec inputs.
+        """
+        
+        InfoMsgs.write('multi input called in', self.title, ':', index)
+        
+        return self.flow.executor.input_values(self, index)
 
     def exec_output(self, index: int):
         """

--- a/ryvencore/Session.py
+++ b/ryvencore/Session.py
@@ -1,7 +1,7 @@
 import importlib
 import glob
 import os.path
-from typing import List, Dict, Type, Optional
+from typing import List, Dict, Type, Optional, Set
 
 from .Data import Data
 from .Base import Base, Event
@@ -33,10 +33,10 @@ class Session(Base):
 
         # ATTRIBUTES
         self.addons = {}
-        self.flows: [Flow] = []
-        self.nodes = set()      # list of node CLASSES
+        self.flows: List[Flow] = []
+        self.nodes: Set[Type[Node]] = set()      # list of node CLASSES
         self.invisible_nodes = set()
-        self.data_types = {}
+        self.data_types: Dict[Data] = {}
         self.gui: bool = gui
         self.init_data = None
 

--- a/tests/data_flow.py
+++ b/tests/data_flow.py
@@ -24,7 +24,7 @@ class Node2(NodeBase):
     init_outputs = []
 
     def update_event(self, inp=-1):
-        print(f'received data on input {inp}: {self.input(inp)}')
+        print(f'received data on input {inp}: {self.input_value(inp)}')
 
 
 class DataFlowBasic(unittest.TestCase):
@@ -55,7 +55,7 @@ class DataFlowBasic(unittest.TestCase):
 
         self.assertEqual(n1.outputs[0].val.payload, 'Hello, World!')
         self.assertEqual(n1.outputs[1].val.payload, 42)
-        self.assertEqual(n3.input(0), n4.input(0))
+        self.assertEqual(n3.input_value(0), n4.input_value(0))
 
         # test save and load
 
@@ -70,9 +70,9 @@ class DataFlowBasic(unittest.TestCase):
 
         n1_2, n2_2, n3_2, n4_2 = f2.nodes
 
-        assert n2_2.input(0).payload == 'Hello, World!'
-        assert n3_2.input(0).payload == 42
-        assert n4_2.input(0).payload == 42
+        assert n2_2.input_value(0).payload == 'Hello, World!'
+        assert n3_2.input_value(0).payload == 42
+        assert n4_2.input_value(0).payload == 42
 
         n1_2.update()
 

--- a/tests/data_objects.py
+++ b/tests/data_objects.py
@@ -19,7 +19,7 @@ class DataTypesBasic(unittest.TestCase):
             self.x = None
 
         def update_event(self, inp=-1):
-            self.x = self.input(0).payload
+            self.x = self.input_value(0).payload
 
     def runTest(self):
         s = rc.Session()
@@ -60,7 +60,7 @@ class DataTypesCustom(unittest.TestCase):
             self.x = None
 
         def update_event(self, inp=-1):
-            self.x = self.input(0).payload
+            self.x = self.input_value(0).payload
 
     def runTest(self):
         s = rc.Session()

--- a/tests/exec_flow.py
+++ b/tests/exec_flow.py
@@ -25,8 +25,8 @@ class Node2(rc.Node):
         self.data = None
 
     def update_event(self, inp=-1):
-        self.data = self.input(1).payload
-        print(f'received data on input {inp}: {self.input(inp)}')
+        self.data = self.input_value(1).payload
+        print(f'received data on input {inp}: {self.input_value(inp)}')
 
 
 class ExecFlowBasic(unittest.TestCase):

--- a/tests/logging-addon.py
+++ b/tests/logging-addon.py
@@ -38,7 +38,7 @@ class Node2(NodeBase):
     init_outputs = []
 
     def update_event(self, inp=-1):
-        print(f'received data on input {inp}: {self.input(inp)}')
+        print(f'received data on input {inp}: {self.input_value(inp)}')
 
 
 class DataFlowBasic(unittest.TestCase):

--- a/tests/variables-addon.py
+++ b/tests/variables-addon.py
@@ -54,7 +54,7 @@ class Node2(NodeBase):
     init_outputs = []
 
     def update_event(self, inp=-1):
-        print(f'received data on input {inp}: {self.input(inp)}')
+        print(f'received data on input {inp}: {self.input_value(inp)}')
 
     def update_var1(self, val):
         self.Vars.var(self.flow, 'var1').set(val)
@@ -84,7 +84,7 @@ class VariablesBasic(unittest.TestCase):
 
         self.assertEqual(n1.outputs[0].val.payload, 'Hello, World!')
         self.assertEqual(n1.outputs[1].val.payload, 42)
-        self.assertEqual(n3.input(0), n4.input(0))
+        self.assertEqual(n3.input_value(0), n4.input_value(0))
 
         # test variables addon
 
@@ -113,8 +113,8 @@ class VariablesBasic(unittest.TestCase):
         n2_2.update_var1('test')
 
         self.assertEqual(n1_2.var_val.get(), 'test')
-        self.assertEqual(n3_2.input(0).payload, 42)
-        self.assertEqual(n4_2.input(0).payload, 42)
+        self.assertEqual(n3_2.input_value(0).payload, 42)
+        self.assertEqual(n4_2.input_value(0).payload, 42)
 
         n1_2.update()
         n2_2.update_var1(43)


### PR DESCRIPTION
I'm submitting this PR as a draft to discuss some features I've been working on in ryvencore as part of a project where I'm using a modified version of Ryven for EEG and Eye Tracking based processing. Its focus is on two main features:

### Multiple Outputs to Single Inputs

I believe this is a must have feature for a graph-based processing library. Shouldn't the user be allowed to connect multiple outputs to a single input? Why should we clutter the graph (in case of a visual representation) with lots of `addition` nodes instead of allowing an addition of N inputs? Something like this:

![Screenshot_12](https://github.com/leon-thomm/ryvencore/assets/135903670/a7461072-dd59-4ed5-b65a-7d0c77574d5f)

seems like a nice thing to have. I have already made the necessary changes for this to work and tested it in my custom version of Ryven. Some noticeable things:

- Changed `input` method of `Node.py` to `input_value` for better clarity (there is an `inputs` attribute that is referring to the actual ports and I thought it was misleading)
- `input_values` returns a list of the values in the given input, in the order they were connected to it (most cases would deem this as undefined order).
- Currently has no way of specifying a max number of allowed connections, but this is easily fixable.
- Tested on custom Ryven version, seems to be working fine, both in runtime and in saving / loading.

### Connection Validity

Despity Python being an interpreted language that doesn't do type checking, I think ryvencore as a library can provide "type checking" for ports. This should be a good addition to have without breaking anything. I've been working on this but have come to a standstill due to some important design decisions. I have not included this code in the PR yet, because I'm open to ideas:

First of all, I believe a validity test function should return an enum, i.e:

```python
class ConnValidType(IntEnum):
    """
    Result from a connection validity test between two node ports
    """

    VALID = auto()
    SAME_NODE = auto()
    SAME_IO = auto()  # if both are input or output
    IO_MISSMATCH = auto() # if output has input pos or input has output pos
    DIFF_ALG_TYPE = auto()  # data or exec
    INVALID_PAYLOAD_TYPE = auto()  # the nodes don't accept any of the same payloads
    
    # input has reached max output connections
    # this should be the last of the checks since it
    # isn't inherently important
    MAX_INP_CONN = auto() 
```
The `MAX_INP_CONN` result should also help in deciding what to do if the port doesn't allow more connections. A validity function can then be something like this:

```python 
def check_conn_validity(out: NodeOutput, inp: NodeInput) -> Tuple[ConnValidType, str]:
    """
    Checks if a connection is valid between two node ports.

    Returns:
        Tuple[ConnValidType, str]: A tuple with the result of the check
        and a detailed reason, if it exists.
    """

    if out.node == inp.node:
        return (ConnValidType.SAME_NODE, "Ports from the same node cannot be connected!")
    
    if out.io_pos == inp.io_pos:
        return (ConnValidType.SAME_IO, "Connections cannot be made between ports of the same pos (inp-inp) or (out-out)")
    
    if out.io_pos != PortObjPos.OUTPUT:
        return (ConnValidType.IO_MISSMATCH, "Output or input must have the corresponding io_pos (PortObjPos) type")
    
    if out.type_ != inp.type_:
        return (ConnValidType.DIFF_ALG_TYPE, "Input and output must both be either exec ports or data ports")
    
    # both ports must require strict payload types for this check
    if out.payload_types and inp.payload_types:
        valid_payload = False
        # at least one payload type must be the same
        for payload_type in out.payload_types:
            if payload_type in inp.payload_types:
                valid_payload = True
                break
    ....
```
And this is the part where I'm kind of stuck. Ryvencore allows custom data types. By wrapping the value in a `Data` class, there are essentially two ways to check for type validity:

- Data: Two ports can accept at least one same `data` type, otherwise connection isn't allowed.
- Payload: Two ports can accept at least one same `payload` type, otherwise connection isn't allowed.

Checking only the payload solves issues of compatibility between different libraries that use the same payload type but different data types. (i.e two separate packages with nodes that process `numpy` arrays that complement each other). However, checking only the payload also causes issues due to the existence of the `data` wrapper. Where do we specify the allowed payload types? In the constructor of `NodeInput` and `NodeOutput`? Or do we create a custom `Data` class and specify the types there?

The way ryvencore is designed, I believe the best solution is the second, i.e:

```python
class IntData(Data):
    allowed_payloads: set = { int }
```
This adds the need to create a custom data class for any payload type checking, which is annoying to say the least, but necessary.

Lastly, I'd like to ask about the `NodePortType` classes. Why have another class for specifying the static init_input and init_output and not simply use the `NodePort` classes?

I want to make clear that I'll be working on these one way or another. This draft is more like a notification for you to decide whether you want to include any of this in the main ryvencore distribution.