### PR TITLE
Data type checking - And a few other things

### DIFF
--- a/ryvencore/Data.py
+++ b/ryvencore/Data.py
@@ -4,7 +4,7 @@ It should be subclassed to define custom data types. In particular, serializatio
 and deserialization must be implemented for each respective type. Types that are
 pickle serializable by default can be used directly with :code`Data(my_data)`.
 """
-from typing import Dict
+from typing import Dict, Type
 
 from ryvencore.Base import Base
 from ryvencore.utils import serialize, deserialize, print_err
@@ -150,5 +150,14 @@ class Data(Base):
         self.set_data(deserialize(data['serialized']))
 
 
+def check_valid_data(out_data_type: Type[Data], inp_data_type: Type[Data]) -> bool:
+    """Returns true if input data can accept the output data, otherwise false"""
+    
+    if inp_data_type is None or out_data_type is Data:
+        return True
+    
+    return issubclass(out_data_type, inp_data_type) 
+    
+    
 # build identifier for Data
 Data._build_identifier()

--- a/ryvencore/Flow.py
+++ b/ryvencore/Flow.py
@@ -371,13 +371,14 @@ class Flow(Base):
         
         out, inp = c
         
-        if inp in self.graph_adj[out]:
-            valid_result = (ConnValidType.ALREADY_CONNECTED, "Connect action invalid on already connected nodes!")
-        elif self.graph_adj_rev.get(inp) is not None:
-            valid_result = (ConnValidType.INPUT_TAKEN, "Input is connected to another output")
-        else:
-            valid_result = check_valid_conn(out, inp)
-            
+        valid_type, _ = valid_result = check_valid_conn(out, inp)
+        
+        if valid_type == ConnValidType.VALID: 
+            if inp in self.graph_adj[out]:
+                valid_result = (ConnValidType.ALREADY_CONNECTED, "Connect action invalid on already connected nodes!")
+            elif self.graph_adj_rev.get(inp) is not None:
+                valid_result = (ConnValidType.INPUT_TAKEN, "Input is connected to another output")
+        
         self.connection_request_valid.emit(valid_result)
         
         return valid_result

--- a/ryvencore/Flow.py
+++ b/ryvencore/Flow.py
@@ -77,7 +77,7 @@ predecessor node `P`, then `P` receives an *update event* with ``inp=-1``, durin
 it should push the output data.
 Therefore, data is not forward propagated on change (``node.set_output_val(index, value)``),
 but generated on request (backwards,
-``node.input_value()`` -> ``pred.update_event()`` -> ``pred.set_output_val()`` -> return).
+``node.input()`` -> ``pred.update_event()`` -> ``pred.set_output_val()`` -> return).
 
 The *exec mode* is still somewhat experimental, because the *data mode* is the far more
 common use case. It is not yet clear how to best implement the *exec mode* in a way that

--- a/ryvencore/Flow.py
+++ b/ryvencore/Flow.py
@@ -364,15 +364,20 @@ class Flow(Base):
     
     def can_nodes_connect(self, c: Tuple[NodeOutput, NodeInput]) -> Tuple[ConnValidType, str]:
         """
-        Same as :code:`Flow.check_connection_validity()` - Also checks if nodes already connected
+        Same as :code:`Flow.check_connection_validity()`
+        
+        Also checks if nodes already connected or if input is connected to another output
         """
         
         out, inp = c
         
-        valid_type, _ = valid_result = check_valid_conn(out, inp)
-        if valid_type == ConnValidType.VALID and inp in self.graph_adj[out]:
+        if inp in self.graph_adj[out]:
             valid_result = (ConnValidType.ALREADY_CONNECTED, "Connect action invalid on already connected nodes!")
-        
+        elif self.graph_adj_rev.get(inp) is not None:
+            valid_result = (ConnValidType.INPUT_TAKEN, "Input is connected to another output")
+        else:
+            valid_result = check_valid_conn(out, inp)
+            
         self.connection_request_valid.emit(valid_result)
         
         return valid_result
@@ -380,15 +385,18 @@ class Flow(Base):
     
     def can_nodes_disconnect(self, c: Tuple[NodeOutput, NodeInput]) -> Tuple[ConnValidType, str]:
         """
-        Same as :code:`Flow.check_connection_validity()` - Also checks if nodes already disconnected
+        Same as :code:`Flow.check_connection_validity()`
+        
+        Also checks if nodes already disconnected
         """
         
         out, inp = c
         
-        valid_type, _ = valid_result = check_valid_conn(out, inp)
-        if valid_type == ConnValidType.VALID and inp not in self.graph_adj[out]:
+        if inp not in self.graph_adj[out]:
             valid_result = (ConnValidType.ALREADY_DISCONNECTED, "Disconnect action invalid on already disconnected nodes!")
-        
+        else:
+            valid_result = check_valid_conn(out, inp)
+            
         self.connection_request_valid.emit(valid_result)
         
         return valid_result

--- a/ryvencore/Flow.py
+++ b/ryvencore/Flow.py
@@ -127,12 +127,12 @@ class Flow(Base):
         # general attributes
         self.session = session
         self.title = title
-        self.nodes: [Node] = []
+        self.nodes: List[Node] = []
         self.load_data = None
 
-        self.node_successors = {}   # additional data structure for executors
-        self.graph_adj = {}         # directed adjacency list relating node ports
-        self.graph_adj_rev = {}     # reverse adjacency; reverse of graph_adj
+        self.node_successors: Dict[Node, List[Node]] = {}   # additional data structure for executors
+        self.graph_adj: Dict[NodeOutput, List[NodeInput]] = {}         # directed adjacency list relating node ports
+        self.graph_adj_rev: Dict[NodeInput, NodeOutput] = {}     # reverse adjacency; reverse of graph_adj
 
         self.alg_mode = FlowAlg.DATA
         self.executor: FlowExecutor = executor_from_flow_alg(self.alg_mode)(self)
@@ -165,7 +165,7 @@ class Flow(Base):
         return new_nodes, new_conns
 
 
-    def _create_nodes_from_data(self, nodes_data: List):
+    def _create_nodes_from_data(self, nodes_data: List) -> List[Node]:
         """create nodes from nodes_data as previously returned by data()"""
 
         nodes = []
@@ -325,10 +325,10 @@ class Flow(Base):
 
         for c in data:
 
-            c_parent_node_index = c['parent node index']
-            c_connected_node_index = c['connected node']
-            c_output_port_index = c['output port index']
-            c_connected_input_port_index = c['connected input port index']
+            c_parent_node_index: int = c['parent node index']
+            c_connected_node_index: int = c['connected node']
+            c_output_port_index: int = c['output port index']
+            c_connected_input_port_index: int = c['connected input port index']
 
             if c_connected_node_index is not None:  # which can be the case when pasting
                 parent_node = nodes[c_parent_node_index]

--- a/ryvencore/Flow.py
+++ b/ryvencore/Flow.py
@@ -346,7 +346,7 @@ class Flow(Base):
         return connections
 
 
-    def check_connection_validity(self, c: Tuple[NodeOutput, NodeInput]):
+    def check_connection_validity(self, c: Tuple[NodeOutput, NodeInput]) -> Tuple[ConnValidType, str]:
         """
         Checks whether a considered connect action is legal.
         """

--- a/ryvencore/Flow.py
+++ b/ryvencore/Flow.py
@@ -77,7 +77,7 @@ predecessor node `P`, then `P` receives an *update event* with ``inp=-1``, durin
 it should push the output data.
 Therefore, data is not forward propagated on change (``node.set_output_val(index, value)``),
 but generated on request (backwards,
-``node.input()`` -> ``pred.update_event()`` -> ``pred.set_output_val()`` -> return).
+``node.input_value()`` -> ``pred.update_event()`` -> ``pred.set_output_val()`` -> return).
 
 The *exec mode* is still somewhat experimental, because the *data mode* is the far more
 common use case. It is not yet clear how to best implement the *exec mode* in a way that

--- a/ryvencore/Flow.py
+++ b/ryvencore/Flow.py
@@ -89,11 +89,11 @@ Assumptions:
 
 """
 from .Base import Base, Event
-from .Data import Data
+from .data.Data import Data
 from .FlowExecutor import DataFlowNaive, DataFlowOptimized, FlowExecutor, executor_from_flow_alg
-from .Node import Node
-from .NodePort import NodeOutput, NodeInput
-from .RC import FlowAlg, PortObjPos
+from .Node import Node, node_from_identifier
+from .NodePort import NodeOutput, NodeInput, check_valid_conn
+from .RC import FlowAlg, PortObjPos, ConnValidType
 from .utils import *
 from typing import List, Dict, Optional, Tuple, Type
 
@@ -353,17 +353,9 @@ class Flow(Base):
 
         out, inp = c
 
-        valid = True
-
-        if out.node == inp.node:
-            valid = False
-
-        if out.io_pos == inp.io_pos or out.type_ != inp.type_:
-            valid = False
-
-        if out.io_pos != PortObjPos.OUTPUT:
-            valid = False
-
+        valid_type, message = check_valid_conn(out, inp)
+        valid = valid_type == ConnValidType.VALID
+        
         self.connection_request_valid.emit(valid)
 
         return valid

--- a/ryvencore/Flow.py
+++ b/ryvencore/Flow.py
@@ -192,7 +192,7 @@ class Flow(Base):
     def _set_output_values_from_data(self, nodes: List[Node], data: List):
         for d in data:
             indices = d['dependent node outputs']
-            indices_paired = zip(indices[0::2], indices[1::2])
+            indices_paired: zip[tuple[int, int]] = zip(indices[0::2], indices[1::2])
             for node_index, output_index in indices_paired:
 
                 # find Data class
@@ -208,8 +208,7 @@ class Flow(Base):
                                   f'Please register data types before using them.')
                         continue
 
-                nodes[node_index].outputs[output_index].val = \
-                    data_type(load_from=d['data'])
+                nodes[node_index]._outputs[output_index].val = data_type(load_from=d['data'])
 
 
     def create_node(self, node_class: Type[Node], data=None):

--- a/ryvencore/Flow.py
+++ b/ryvencore/Flow.py
@@ -72,7 +72,7 @@ but without any data being propagated, so it's just a trigger signal.
 Pushing output data, however, does not cause updates in successor nodes.
 
 When a node is updated (it received an *update event* through an *exec connection*), once it
-needs input data (it calls ``self.input_value(index)``), if that input is connected to some
+needs input data (it calls ``self.input(index)``), if that input is connected to some
 predecessor node `P`, then `P` receives an *update event* with ``inp=-1``, during which
 it should push the output data.
 Therefore, data is not forward propagated on change (``node.set_output_val(index, value)``),
@@ -127,12 +127,12 @@ class Flow(Base):
         # general attributes
         self.session = session
         self.title = title
-        self.nodes: List[Node] = []
+        self.nodes: [Node] = []
         self.load_data = None
 
-        self.node_successors: Dict[Node, List[Node]] = {}   # additional data structure for executors
-        self.graph_adj: Dict[NodeOutput, List[NodeInput]] = {}         # directed adjacency list relating node ports
-        self.graph_adj_rev: Dict[NodeInput, List[NodeOutput]] = {}     # reverse adjacency; reverse of graph_adj
+        self.node_successors = {}   # additional data structure for executors
+        self.graph_adj = {}         # directed adjacency list relating node ports
+        self.graph_adj_rev = {}     # reverse adjacency; reverse of graph_adj
 
         self.alg_mode = FlowAlg.DATA
         self.executor: FlowExecutor = executor_from_flow_alg(self.alg_mode)(self)
@@ -165,7 +165,7 @@ class Flow(Base):
         return new_nodes, new_conns
 
 
-    def _create_nodes_from_data(self, nodes_data: List) -> List[Node]:
+    def _create_nodes_from_data(self, nodes_data: List):
         """create nodes from nodes_data as previously returned by data()"""
 
         nodes = []
@@ -291,7 +291,7 @@ class Flow(Base):
     def add_node_input(self, node: Node, inp: NodeInput, _call_flow_changed=True):
         """updates internal data structures"""
         if node in self.node_successors:
-            self.graph_adj_rev[inp] = []
+            self.graph_adj_rev[inp] = None
             if _call_flow_changed:
                 self._flow_changed()
 
@@ -325,10 +325,10 @@ class Flow(Base):
 
         for c in data:
 
-            c_parent_node_index: int = c['parent node index']
-            c_connected_node_index: int = c['connected node']
-            c_output_port_index: int = c['output port index']
-            c_connected_input_port_index: int = c['connected input port index']
+            c_parent_node_index = c['parent node index']
+            c_connected_node_index = c['connected node']
+            c_output_port_index = c['output port index']
+            c_connected_input_port_index = c['connected input port index']
 
             if c_connected_node_index is not None:  # which can be the case when pasting
                 parent_node = nodes[c_parent_node_index]
@@ -409,11 +409,9 @@ class Flow(Base):
         out, inp = c
 
         self.graph_adj[out].append(inp)
-        self.graph_adj_rev[inp].append(out)
+        self.graph_adj_rev[inp] = out
 
-        successor = self.node_successors[out.node]
-        if inp.node not in successor:
-            self.node_successors[out.node].append(inp.node)
+        self.node_successors[out.node].append(inp.node)
         self._flow_changed()
 
 
@@ -429,20 +427,10 @@ class Flow(Base):
 
         out, inp = c
 
-        out_inputs = self.graph_adj[out]
-        out_inputs.remove(inp)
-        self.graph_adj_rev[inp].remove(out)
-        
-        # find if the nodes are still connected via another connection
-        node_found_count = 0
-        for inp_port in out_inputs:
-            if inp_port.node == inp.node:
-                node_found_count += 1
-        
-        # remove the node only if it isn't connected
-        if node_found_count == 0:
-            self.node_successors[out.node].remove(inp.node)
-        
+        self.graph_adj[out].remove(inp)
+        self.graph_adj_rev[inp] = None
+
+        self.node_successors[out.node].remove(inp.node)
         self._flow_changed()
 
         self.executor.conn_removed(out, inp, silent=silent)
@@ -457,21 +445,13 @@ class Flow(Base):
         return self.graph_adj[out]
 
 
-    def connected_outputs(self, inp: NodeInput) -> List[NodeOutput]:
+    def connected_output(self, inp: NodeInput) -> Optional[NodeOutput]:
         """
-        Returns a list of all connected outputs to the given input port.
+        Returns the connected output port to the given input port, or
+        :code:`None` if it is not connected.
         """
         return self.graph_adj_rev[inp]
 
-
-    def connection_exists(self, out: NodeOutput, inp: NodeInput):
-        return inp in self.graph_adj[out]
-    
-    
-    def connection_exists_tuple(self, connection: Tuple[NodeOutput, NodeInput]):
-        out, inp = connection
-        return self.connection_exists(out, inp)
-    
 
     def algorithm_mode(self) -> str:
         """

--- a/ryvencore/FlowExecutor.py
+++ b/ryvencore/FlowExecutor.py
@@ -3,7 +3,7 @@ The flow executors are responsible for executing the flow. They have access to
 the flow as well as the nodes' internals and are able to perform optimizations.
 """
 from . import Flow, Node
-from .Data import Data
+from .data.Data import Data
 from .NodePort import NodeOutput, NodeInput
 from .RC import FlowAlg
 

--- a/ryvencore/FlowExecutor.py
+++ b/ryvencore/FlowExecutor.py
@@ -31,12 +31,8 @@ class FlowExecutor:
     def update_node(self, node: Node, inp: int):
         pass
 
-    # Node.input_value() =>
-    def input_value(self, node: Node, index: int):
-        pass
-    
-    # Node.input_values() =>
-    def input_values(self, node: Node, index: int):
+    # Node.input() =>
+    def input(self, node: Node, index: int):
         pass
 
     # Node.set_output_val() =>
@@ -72,28 +68,16 @@ class DataFlowNaive(FlowExecutor):
         except Exception as e:
             node.update_err(e)
 
-    # Node.input_value() =>
-    def input_value(self, node: Node, index: int):
+    # Node.input() =>
+    def input(self, node: Node, index: int):
         inp = node.inputs[index]
-        conn_outs = self.graph_rev[inp]
+        conn_out = self.graph_rev[inp]
 
-        if len(conn_outs) != 0:
-            conn_out = conn_outs[0]
-            if conn_out:
-                return conn_out.val
+        if conn_out:
+            return conn_out.val
         else:
             return inp.default
 
-    # Node.input_values() =>
-    def input_values(self, node: Node, index: int):
-        inp = node.inputs[index]
-        conn_outs = self.graph_rev[inp]
-        
-        if len(conn_outs) == 0:
-            return None
-        
-        return [conn_out.val for conn_out in conn_outs]
-        
     # Node.set_output_val() =>
     def set_output_val(self, node: Node, index: int, data):
         out = node.outputs[index]
@@ -352,18 +336,17 @@ class ExecFlowNaive(FlowExecutor):
             self.updated_nodes = None
 
     # Node.input() =>
-    def input_value(self, node, index):
+    def input(self, node, index):
         inp = node.inputs[index]
-        out_ports = self.graph_rev[inp]
-        
-        result = []
-        for out in out_ports:
+        out = self.graph_rev[inp]
+        if out:
             n = out.node
             if n not in self.updated_nodes:
                 n.update(-1)
-            result.append(out.val)
 
-        return result if len(result) > 0 else None
+            return out.val
+        else:
+            return None
 
     # Node.set_output_val() =>
     def set_output_val(self, node, index, data):

--- a/ryvencore/Node.py
+++ b/ryvencore/Node.py
@@ -15,6 +15,7 @@ from copy import copy
 
 if TYPE_CHECKING:
     from .Flow import Flow
+    from .Session import Session
 
 class Node(Base):
     """
@@ -73,8 +74,9 @@ class Node(Base):
     def __init__(self, params):
         Base.__init__(self)
 
-        self.flow, self.session = params
-        self.flow: Flow = self.flow
+        flow, session = params
+        self.flow: Flow = flow
+        self.session: Session = session
         
         self._inputs: List[NodeInput] = []
         self._outputs: List[NodeOutput] = []

--- a/ryvencore/Node.py
+++ b/ryvencore/Node.py
@@ -163,29 +163,16 @@ class Node(Base):
         InfoMsgs.write_err('EXCEPTION in', self.title, '\n', traceback.format_exc())
         self.update_error.emit(e)
 
-    def input_value(self, index: int) -> Optional[Data]:
+    def input(self, index: int) -> Optional[Data]:
         """
-        Returns the data residing at the first input of given index. This is 
-        essentially the value at the first connection made to this input.
+        Returns the data residing at the data input of given index.
 
         Do not call on exec inputs.
         """
 
-        InfoMsgs.write('first input called in', self.title, ':', index)
+        InfoMsgs.write('input called in', self.title, ':', index)
 
-        return self.flow.executor.input_value(self, index)
-    
-    def input_values(self, index: int) -> Optional[List[Data]]:
-        """
-        Returns a new list of data for all connections to this input.
-        Ordered from first connection made to last
-        
-        Do not call on exec inputs.
-        """
-        
-        InfoMsgs.write('multi input called in', self.title, ':', index)
-        
-        return self.flow.executor.input_values(self, index)
+        return self.flow.executor.input(self, index)
 
     def exec_output(self, index: int):
         """

--- a/ryvencore/Node.py
+++ b/ryvencore/Node.py
@@ -79,11 +79,13 @@ class Node(Base):
 
         # events
         self.updating = Event(int)
+        self.updated = Event(int)
         self.update_error = Event(Exception)
         self.input_added = Event(Node, int, NodeInput)
         self.input_removed = Event(Node, int, NodeInput)
         self.output_added = Event(Node, int, NodeOutput)
         self.output_removed = Event(Node, int, NodeOutput)
+        self.output_changed = Event(Node, int, NodeOutput, Data)
 
     def initialize(self):
         """
@@ -158,6 +160,7 @@ class Node(Base):
         # invoke update_event
         self.updating.emit(inp)
         self.flow.executor.update_node(self, inp)
+        self.updated.emit(inp)
 
     def update_err(self, e):
         InfoMsgs.write_err('EXCEPTION in', self.title, '\n', traceback.format_exc())
@@ -194,6 +197,8 @@ class Node(Base):
         InfoMsgs.write('setting output', index, 'in', self.title)
 
         self.flow.executor.set_output_val(self, index, data)
+        
+        self.output_changed.emit(self, index, self.outputs[index], data)
 
     """
     

--- a/ryvencore/Node.py
+++ b/ryvencore/Node.py
@@ -5,7 +5,7 @@ from .Base import Base, Event
 
 from .NodePort import NodeInput, NodeOutput
 from .NodePortType import NodeInputType, NodeOutputType
-from .data.Data import Data, payload_to_data
+from .data.Data import Data
 from .InfoMsgs import InfoMsgs
 from .utils import serialize, deserialize
 from .RC import ProgressState
@@ -227,21 +227,6 @@ class Node(Base):
         self.flow.executor.set_output_val(self, index, data)
         
         self.output_updated.emit(self, index, self._outputs[index], data)
-
-    def set_output_payload(self, index: int, payload):
-        """
-        Wrapper of :code:`set_output_val()` that creates the data type from the payload type.
-        
-        Data and payload types must be associated with register_payload_to_data found in Data module.
-        
-        This function assumes the derived Data type's constructor works at least with a payload argument.
-        Defaults to the base Data type if an association isn't found 
-        """
-        
-        data_type = payload_to_data.get(type(payload))
-        data = data_type(payload) if data_type else Data(payload)
-        
-        self.set_output_val(index, data)
     
     """
     

--- a/ryvencore/Node.py
+++ b/ryvencore/Node.py
@@ -163,16 +163,29 @@ class Node(Base):
         InfoMsgs.write_err('EXCEPTION in', self.title, '\n', traceback.format_exc())
         self.update_error.emit(e)
 
-    def input(self, index: int) -> Optional[Data]:
+    def input_value(self, index: int) -> Optional[Data]:
         """
-        Returns the data residing at the data input of given index.
+        Returns the data residing at the first input of given index. This is 
+        essentially the value at the first connection made to this input.
 
         Do not call on exec inputs.
         """
 
-        InfoMsgs.write('input called in', self.title, ':', index)
+        InfoMsgs.write('first input called in', self.title, ':', index)
 
-        return self.flow.executor.input(self, index)
+        return self.flow.executor.input_value(self, index)
+    
+    def input_values(self, index: int) -> Optional[List[Data]]:
+        """
+        Returns a new list of data for all connections to this input.
+        Ordered from first connection made to last
+        
+        Do not call on exec inputs.
+        """
+        
+        InfoMsgs.write('multi input called in', self.title, ':', index)
+        
+        return self.flow.executor.input_values(self, index)
 
     def exec_output(self, index: int):
         """

--- a/ryvencore/Node.py
+++ b/ryvencore/Node.py
@@ -448,7 +448,7 @@ class Node(Base):
         """Sets the progress, allowing to turn it into a percentage"""
         if progress_state is not None and as_percentage:
             progress_state = progress_state.as_percentage()
-        self._progress.value = progress_state
+        self._progress = progress_state
         self.progress_updated.emit(self._progress)
     
     def set_progress_value(self, value: Real, message: str = None, as_percentage: bool = False):

--- a/ryvencore/NodePort.py
+++ b/ryvencore/NodePort.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Tuple
+from typing import Optional, Dict
 
 from . import Node
 from .Data import Data
@@ -6,38 +6,12 @@ from .Base import Base
 from .utils import serialize, deserialize
 
 from .RC import PortObjPos
-from enum import IntEnum, auto
 
-import json
-
-
-class ConnValidType(IntEnum):
-    """
-    Result from a connection validity test between two node ports
-    """
-
-    VALID = auto()
-    SAME_NODE = auto()
-    SAME_IO = auto()  # if both are input or output
-    IO_MISSMATCH = auto() # if output has input pos or input has output pos
-    DIFF_ALG_TYPE = auto()  # data or exec
-    INVALID_PAYLOAD_TYPE = auto()  # the nodes don't accept any of the same payloads
-    
-    # input has reached max output connections
-    # this should be the last of the checks since it
-    # isn't inherently important
-    MAX_INP_CONN = auto() 
 
 class NodePort(Base):
-    """
-    Base class for inputs and outputs of nodes. The payload_types
-    refers to the allowed types that a Data.payload might receive.
-    If none or empty, any type can be connected.
-    """
+    """Base class for inputs and outputs of nodes"""
 
-    def __init__(
-        self, node: Node, io_pos: PortObjPos, type_: str, label_str: str, payload_types: set = None
-    ):
+    def __init__(self, node: Node, io_pos: PortObjPos, type_: str, label_str: str):
         Base.__init__(self)
 
         self.node = node
@@ -45,54 +19,26 @@ class NodePort(Base):
         self.type_ = type_
         self.label_str = label_str
         self.load_data = None
-        self.payload_types = payload_types
 
     def load(self, data: Dict):
         self.load_data = data
         self.type_ = data['type']
         self.label_str = data['label']
 
-        payload_types = data.get('payload_types')
-        if payload_types is None:
-            self.payload_types = None
-        else:
-            self.payload_types = json.loads(payload_types)
-
     def data(self) -> dict:
-        if self.payload_types is None:
-            payload_type_data = None
-        else:
-            payload_type_data = [f'{t.__module__}.{t.__name__}' for t in self.payload_types]
         return {
             **super().data(),
             'type': self.type_,
             'label': self.label_str,
-            'payload_types': json.dumps(payload_type_data),
         }
 
 
 class NodeInput(NodePort):
-    """
-    A node input port. This allows to specify how many output connections
-    are allowed to be made to this port.
-    
-    max_connections > 0 (default=1): Up to N connections
-    max_connections <= 0 : Infinite connections
-    """
-    
-    def __init__(
-        self,
-        node: Node,
-        type_: str,
-        label_str: str = '',
-        default: Optional[Data] = None,
-        payload_types: set = None,
-        max_connections: int = 1,
-    ):
-        super().__init__(node, PortObjPos.INPUT, type_, label_str, payload_types)
+
+    def __init__(self, node: Node, type_: str, label_str: str = '', default: Optional[Data] = None):
+        super().__init__(node, PortObjPos.INPUT, type_, label_str)
 
         self.default: Optional[Data] = default
-        self.max_connections = max_connections
 
     def load(self, data: Dict):
         super().load(data)
@@ -107,10 +53,9 @@ class NodeInput(NodePort):
             **default,
         }
 
-
 class NodeOutput(NodePort):
-    def __init__(self, node: Node, type_: str, label_str: str = '', payload_types: set = None):
-        super().__init__(node, PortObjPos.OUTPUT, type_, label_str, payload_types)
+    def __init__(self, node: Node, type_: str, label_str: str = ''):
+        super().__init__(node, PortObjPos.OUTPUT, type_, label_str)
 
         self.val: Optional[Data] = None
 
@@ -120,39 +65,3 @@ class NodeOutput(NodePort):
     #     data['val'] = self.val if self.val is None else self.val.get_data()
     #
     #     return data
-
-
-def check_conn_validity(out: NodeOutput, inp: NodeInput) -> Tuple[ConnValidType, str]:
-    """
-    Checks if a connection is valid between two node ports.
-
-    Returns:
-        Tuple[ConnValidType, str]: A tuple with the result of the check
-        and a detailed reason, if it exists.
-    """
-
-    if out.node == inp.node:
-        return (ConnValidType.SAME_NODE, "Ports from the same node cannot be connected!")
-    
-    if out.io_pos == inp.io_pos:
-        return (ConnValidType.SAME_IO, "Connections cannot be made between ports of the same pos (inp-inp) or (out-out)")
-    
-    if out.io_pos != PortObjPos.OUTPUT:
-        return (ConnValidType.IO_MISSMATCH, "Output or input must have the corresponding io_pos (PortObjPos) type")
-    
-    if out.type_ != inp.type_:
-        return (ConnValidType.DIFF_ALG_TYPE, "Input and output must both be either exec ports or data ports")
-    
-    # both ports must require strict payload types for this check
-    if out.payload_types and inp.payload_types:
-        valid_payload = False
-        # at least one payload type must be the same
-        for payload_type in out.payload_types:
-            if payload_type in inp.payload_types:
-                valid_payload = True
-                break
-        
-
-def check_conn_validity_tuple(conn: Tuple[NodeOutput, NodeInput]):
-    out, inp = conn
-    return check_conn_validity(out, inp)

--- a/ryvencore/NodePort.py
+++ b/ryvencore/NodePort.py
@@ -101,20 +101,4 @@ def check_valid_conn(out: NodeOutput, inp: NodeInput) -> ConnValidType:
 def check_valid_conn_tuple(connection: Tuple[NodeOutput, NodeInput]):
     out, inp = connection
     return check_valid_conn(out, inp)
-
-def get_error_message(conn_valid_type: ConnValidType, out: NodeOutput, inp: NodeInput) -> str:
-    """An error message for the various ConnValidType types"""
-    
-    if conn_valid_type == ConnValidType.SAME_NODE: 
-        return "Ports from the same node cannot be connected!"
-    elif conn_valid_type == ConnValidType.SAME_IO:
-        return "Connections cannot be made between ports of the same pos (inp-inp) or (out-out)"
-    elif conn_valid_type == ConnValidType.IO_MISSMATCH:
-        return f"Output io_pos should be {PortObjPos.OUTPUT} but instead is {out.io_pos}"
-    elif conn_valid_type == ConnValidType.DIFF_ALG_TYPE:
-        return "Input and output must both be either exec ports or data ports"
-    elif conn_valid_type == ConnValidType.DATA_MISSMATCH:
-        return f"When input type is defined, output type must be a (sub)class of input type\n [out={out.allowed_data}, inp={inp.allowed_data}]"
-    
-    return "Valid!"
     

--- a/ryvencore/NodePort.py
+++ b/ryvencore/NodePort.py
@@ -1,17 +1,15 @@
-from typing import Optional, Dict, Type
+from typing import Optional, Dict, Type, Tuple
 
-from . import Node
-from .Data import Data
 from .Base import Base
 from .utils import serialize, deserialize
 
-from .RC import PortObjPos
-
+from .RC import PortObjPos, ConnValidType
+from .data import Data, check_valid_data
 
 class NodePort(Base):
     """Base class for inputs and outputs of nodes"""
 
-    def __init__(self, node: Node, io_pos: PortObjPos, type_: str, label_str: str, allowed_data: Optional[Type[Data]] = None):
+    def __init__(self, node, io_pos: PortObjPos, type_: str, label_str: str, allowed_data: Optional[Type[Data]] = None):
         Base.__init__(self)
 
         self.node = node
@@ -25,18 +23,23 @@ class NodePort(Base):
         self.load_data = data
         self.type_ = data['type']
         self.label_str = data['label']
-
+        # allowed data - backwards compatibility
+        data_id = data.get('allowed_data')
+        if data_id is not None:
+            self.allowed_data = self.node.session.get_data_type(data_id)
+        
     def data(self) -> dict:
         return {
             **super().data(),
             'type': self.type_,
             'label': self.label_str,
+            'allowed_data': self.allowed_data.identifier if self.allowed_data is not None else None
         }
 
 
 class NodeInput(NodePort):
 
-    def __init__(self, node: Node, type_: str, label_str: str = '', default: Optional[Data] = None, allowed_data: Optional[Type[Data]] = None):
+    def __init__(self, node, type_: str, label_str: str = '', default: Optional[Data] = None, allowed_data: Optional[Type[Data]] = None):
         super().__init__(node, PortObjPos.INPUT, type_, label_str, allowed_data)
 
         self.default: Optional[Data] = default
@@ -55,7 +58,7 @@ class NodeInput(NodePort):
         }
 
 class NodeOutput(NodePort):
-    def __init__(self, node: Node, type_: str, label_str: str = '', allowed_data: Optional[Type[Data]] = None):
+    def __init__(self, node, type_: str, label_str: str = '', allowed_data: Optional[Type[Data]] = None):
         super().__init__(node, PortObjPos.OUTPUT, type_, label_str, allowed_data)
 
         self.val: Optional[Data] = None
@@ -66,3 +69,34 @@ class NodeOutput(NodePort):
     #     data['val'] = self.val if self.val is None else self.val.get_data()
     #
     #     return data
+
+def check_valid_conn(out: NodeOutput, inp: NodeInput) -> Tuple[ConnValidType, str]:
+    """
+    Checks if a connection is valid between two node ports.
+
+    Returns:
+        A tuple with the result of the check and a detailed reason, if it exists.
+    """
+    
+    if out.node == inp.node:
+        return (ConnValidType.SAME_NODE, "Ports from the same node cannot be connected!")
+    
+    if out.io_pos == inp.io_pos:
+        return (ConnValidType.SAME_IO, "Connections cannot be made between ports of the same pos (inp-inp) or (out-out)")
+    
+    if out.io_pos != PortObjPos.OUTPUT:
+        return (ConnValidType.IO_MISSMATCH, f"Output io_pos should be {PortObjPos.OUTPUT} but instead is {out.io_pos}")
+    
+    if out.type_ != inp.type_:
+        return (ConnValidType.DIFF_ALG_TYPE, "Input and output must both be either exec ports or data ports")
+    
+    if not check_valid_data(out.allowed_data, inp.allowed_data):
+        return (ConnValidType.DATA_MISSMATCH, 
+                f"When input type is defined, output type must be a (sub)class of input type\n [out={out.allowed_data}, inp={inp.allowed_data}]")
+    
+    return (ConnValidType.VALID, "Connection is valid!")
+
+
+def check_valid_conn_tuple(connection: Tuple[NodeOutput, NodeInput]):
+    out, inp = connection
+    return check_valid_conn(out, inp)

--- a/ryvencore/NodePort.py
+++ b/ryvencore/NodePort.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict
+from typing import Optional, Dict, Tuple
 
 from . import Node
 from .Data import Data
@@ -6,12 +6,38 @@ from .Base import Base
 from .utils import serialize, deserialize
 
 from .RC import PortObjPos
+from enum import IntEnum, auto
 
+import json
+
+
+class ConnValidType(IntEnum):
+    """
+    Result from a connection validity test between two node ports
+    """
+
+    VALID = auto()
+    SAME_NODE = auto()
+    SAME_IO = auto()  # if both are input or output
+    IO_MISSMATCH = auto() # if output has input pos or input has output pos
+    DIFF_ALG_TYPE = auto()  # data or exec
+    INVALID_PAYLOAD_TYPE = auto()  # the nodes don't accept any of the same payloads
+    
+    # input has reached max output connections
+    # this should be the last of the checks since it
+    # isn't inherently important
+    MAX_INP_CONN = auto() 
 
 class NodePort(Base):
-    """Base class for inputs and outputs of nodes"""
+    """
+    Base class for inputs and outputs of nodes. The payload_types
+    refers to the allowed types that a Data.payload might receive.
+    If none or empty, any type can be connected.
+    """
 
-    def __init__(self, node: Node, io_pos: PortObjPos, type_: str, label_str: str):
+    def __init__(
+        self, node: Node, io_pos: PortObjPos, type_: str, label_str: str, payload_types: set = None
+    ):
         Base.__init__(self)
 
         self.node = node
@@ -19,26 +45,54 @@ class NodePort(Base):
         self.type_ = type_
         self.label_str = label_str
         self.load_data = None
+        self.payload_types = payload_types
 
     def load(self, data: Dict):
         self.load_data = data
         self.type_ = data['type']
         self.label_str = data['label']
 
+        payload_types = data.get('payload_types')
+        if payload_types is None:
+            self.payload_types = None
+        else:
+            self.payload_types = json.loads(payload_types)
+
     def data(self) -> dict:
+        if self.payload_types is None:
+            payload_type_data = None
+        else:
+            payload_type_data = [f'{t.__module__}.{t.__name__}' for t in self.payload_types]
         return {
             **super().data(),
             'type': self.type_,
             'label': self.label_str,
+            'payload_types': json.dumps(payload_type_data),
         }
 
 
 class NodeInput(NodePort):
-
-    def __init__(self, node: Node, type_: str, label_str: str = '', default: Optional[Data] = None):
-        super().__init__(node, PortObjPos.INPUT, type_, label_str)
+    """
+    A node input port. This allows to specify how many output connections
+    are allowed to be made to this port.
+    
+    max_connections > 0 (default=1): Up to N connections
+    max_connections <= 0 : Infinite connections
+    """
+    
+    def __init__(
+        self,
+        node: Node,
+        type_: str,
+        label_str: str = '',
+        default: Optional[Data] = None,
+        payload_types: set = None,
+        max_connections: int = 1,
+    ):
+        super().__init__(node, PortObjPos.INPUT, type_, label_str, payload_types)
 
         self.default: Optional[Data] = default
+        self.max_connections = max_connections
 
     def load(self, data: Dict):
         super().load(data)
@@ -53,9 +107,10 @@ class NodeInput(NodePort):
             **default,
         }
 
+
 class NodeOutput(NodePort):
-    def __init__(self, node: Node, type_: str, label_str: str = ''):
-        super().__init__(node, PortObjPos.OUTPUT, type_, label_str)
+    def __init__(self, node: Node, type_: str, label_str: str = '', payload_types: set = None):
+        super().__init__(node, PortObjPos.OUTPUT, type_, label_str, payload_types)
 
         self.val: Optional[Data] = None
 
@@ -65,3 +120,39 @@ class NodeOutput(NodePort):
     #     data['val'] = self.val if self.val is None else self.val.get_data()
     #
     #     return data
+
+
+def check_conn_validity(out: NodeOutput, inp: NodeInput) -> Tuple[ConnValidType, str]:
+    """
+    Checks if a connection is valid between two node ports.
+
+    Returns:
+        Tuple[ConnValidType, str]: A tuple with the result of the check
+        and a detailed reason, if it exists.
+    """
+
+    if out.node == inp.node:
+        return (ConnValidType.SAME_NODE, "Ports from the same node cannot be connected!")
+    
+    if out.io_pos == inp.io_pos:
+        return (ConnValidType.SAME_IO, "Connections cannot be made between ports of the same pos (inp-inp) or (out-out)")
+    
+    if out.io_pos != PortObjPos.OUTPUT:
+        return (ConnValidType.IO_MISSMATCH, "Output or input must have the corresponding io_pos (PortObjPos) type")
+    
+    if out.type_ != inp.type_:
+        return (ConnValidType.DIFF_ALG_TYPE, "Input and output must both be either exec ports or data ports")
+    
+    # both ports must require strict payload types for this check
+    if out.payload_types and inp.payload_types:
+        valid_payload = False
+        # at least one payload type must be the same
+        for payload_type in out.payload_types:
+            if payload_type in inp.payload_types:
+                valid_payload = True
+                break
+        
+
+def check_conn_validity_tuple(conn: Tuple[NodeOutput, NodeInput]):
+    out, inp = conn
+    return check_conn_validity(out, inp)

--- a/ryvencore/NodePort.py
+++ b/ryvencore/NodePort.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict
+from typing import Optional, Dict, Type
 
 from . import Node
 from .Data import Data
@@ -11,7 +11,7 @@ from .RC import PortObjPos
 class NodePort(Base):
     """Base class for inputs and outputs of nodes"""
 
-    def __init__(self, node: Node, io_pos: PortObjPos, type_: str, label_str: str):
+    def __init__(self, node: Node, io_pos: PortObjPos, type_: str, label_str: str, allowed_data: Optional[Type[Data]] = None):
         Base.__init__(self)
 
         self.node = node
@@ -19,6 +19,7 @@ class NodePort(Base):
         self.type_ = type_
         self.label_str = label_str
         self.load_data = None
+        self.allowed_data = allowed_data
 
     def load(self, data: Dict):
         self.load_data = data
@@ -35,8 +36,8 @@ class NodePort(Base):
 
 class NodeInput(NodePort):
 
-    def __init__(self, node: Node, type_: str, label_str: str = '', default: Optional[Data] = None):
-        super().__init__(node, PortObjPos.INPUT, type_, label_str)
+    def __init__(self, node: Node, type_: str, label_str: str = '', default: Optional[Data] = None, allowed_data: Optional[Type[Data]] = None):
+        super().__init__(node, PortObjPos.INPUT, type_, label_str, allowed_data)
 
         self.default: Optional[Data] = default
 
@@ -54,8 +55,8 @@ class NodeInput(NodePort):
         }
 
 class NodeOutput(NodePort):
-    def __init__(self, node: Node, type_: str, label_str: str = ''):
-        super().__init__(node, PortObjPos.OUTPUT, type_, label_str)
+    def __init__(self, node: Node, type_: str, label_str: str = '', allowed_data: Optional[Type[Data]] = None):
+        super().__init__(node, PortObjPos.OUTPUT, type_, label_str, allowed_data)
 
         self.val: Optional[Data] = None
 

--- a/ryvencore/NodePortType.py
+++ b/ryvencore/NodePortType.py
@@ -1,9 +1,9 @@
 from typing import Optional
+from dataclasses import dataclass
+from .data.Data import Data
 
-from .Data import Data
 
-
-# TODO: make this a dataclass
+@dataclass
 class NodePortType:
     """
     The NodePortBP classes are only placeholders (BP = BluePrint) for the static init_input and
@@ -11,19 +11,15 @@ class NodePortType:
     An instantiated Node's actual inputs and outputs will be of type NodeObjPort (NodeObjInput, NodeObjOutput).
     """
 
-    def __init__(self, label: str = '', type_: str = 'data'):
-
-        self.type_: str = type_
-        self.label: str = label
-
+    label: str = ''
+    type_: str = 'data'
+    allowed_data: Data = None
+        
 
 class NodeInputType(NodePortType):
-    def __init__(self, label: str = '', type_: str = 'data', default: Optional[Data] = None):
-        super().__init__(label, type_)
-
-        self.default: Optional[Data] = default
+    
+    default: Optional[Data] = None
 
 
 class NodeOutputType(NodePortType):
-    def __init__(self, label: str = '', type_: str = 'data'):
-        super().__init__(label, type_)
+    pass

--- a/ryvencore/RC.py
+++ b/ryvencore/RC.py
@@ -80,6 +80,13 @@ class ProgressState:
     A negative value indicates indefinite progress
     """
     
+    __INDEFINITE_PROGRESS: int = -1
+    
+    @classmethod
+    @property
+    def IMMUTABLE_PROGRESS(cls):
+        return cls.__INDEFINITE_PROGRESS
+    
     def __init__(self, max_value: Real = 1, value: Real = 0, message: str = ''):
         self._max_value = max_value
         self._value = value

--- a/ryvencore/RC.py
+++ b/ryvencore/RC.py
@@ -2,6 +2,10 @@
 
 from enum import IntEnum, auto
 from numbers import Real
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .NodePort import NodeOutput, NodeInput
 
 class FlowAlg(IntEnum):
     """Used for performance reasons"""
@@ -81,6 +85,23 @@ class ConnValidType(IntEnum):
     
     Optional Check - A disconnect action was attemped on disconnected ports!
     """
+    
+    @classmethod
+    def get_error_message(cls, conn_valid_type: 'ConnValidType', out: 'NodeOutput', inp: 'NodeInput') -> str:
+        """An error message for the various ConnValidType types"""
+    
+        if conn_valid_type == ConnValidType.SAME_NODE: 
+            return "Ports from the same node cannot be connected!"
+        elif conn_valid_type == ConnValidType.SAME_IO:
+            return "Connections cannot be made between ports of the same pos (inp-inp) or (out-out)"
+        elif conn_valid_type == ConnValidType.IO_MISSMATCH:
+            return f"Output io_pos should be {PortObjPos.OUTPUT} but instead is {out.io_pos}"
+        elif conn_valid_type == ConnValidType.DIFF_ALG_TYPE:
+            return "Input and output must both be either exec ports or data ports"
+        elif conn_valid_type == ConnValidType.DATA_MISSMATCH:
+            return f"When input type is defined, output type must be a (sub)class of input type\n [out={out.allowed_data}, inp={inp.allowed_data}]"
+    
+        return "Valid!"
 
     
 class ProgressState:

--- a/ryvencore/RC.py
+++ b/ryvencore/RC.py
@@ -49,22 +49,32 @@ class ConnValidType(IntEnum):
 
     VALID = auto()
     """Valid Connection"""
+    
     SAME_NODE = auto()
     """Invalid Connection due to same node"""
+    
     SAME_IO = auto()
     """Invalid Connection due to both ports being input or output"""
+    
     IO_MISSMATCH = auto()
     """Invalid Connection due to output being an input and vice-versa"""
+    
     DIFF_ALG_TYPE = auto()
     """Invalid Connection due to different algorithm types (data or exec)"""
+    
     DATA_MISSMATCH = auto()
     """Invalid Connection due to input / output Data type checking"""
+    
+    INPUT_TAKEN = auto()
+    """Invalid Connection due to input being connected to another output"""
+    
     ALREADY_CONNECTED = auto()
     """
     Invalid Connect check
     
     Optional Check - A connect action was attempted but nodes were already connected!
     """
+    
     ALREADY_DISCONNECTED = auto()
     """
     Invalid Disconnect check
@@ -72,7 +82,7 @@ class ConnValidType(IntEnum):
     Optional Check - A disconnect action was attemped on disconnected ports!
     """
 
-
+    
 class ProgressState:
     """
     Represents a progress state / bar.
@@ -84,7 +94,7 @@ class ProgressState:
     
     @classmethod
     @property
-    def IMMUTABLE_PROGRESS(cls):
+    def INDEFINITE_PROGRESS(cls):
         return cls.__INDEFINITE_PROGRESS
     
     def __init__(self, max_value: Real = 1, value: Real = 0, message: str = ''):

--- a/ryvencore/RC.py
+++ b/ryvencore/RC.py
@@ -59,6 +59,18 @@ class ConnValidType(IntEnum):
     """Invalid Connection due to different algorithm types (data or exec)"""
     DATA_MISSMATCH = auto()
     """Invalid Connection due to input / output Data type checking"""
+    ALREADY_CONNECTED = auto()
+    """
+    Invalid Connect check
+    
+    Optional Check - A connect action was attempted but nodes were already connected!
+    """
+    ALREADY_DISCONNECTED = auto()
+    """
+    Invalid Disconnect check
+    
+    Optional Check - A disconnect action was attemped on disconnected ports!
+    """
 
 
 class ProgressState:

--- a/ryvencore/RC.py
+++ b/ryvencore/RC.py
@@ -1,7 +1,7 @@
 """Namespace for enum types etc."""
 
 from enum import IntEnum, auto
-
+from numbers import Real
 
 class FlowAlg(IntEnum):
     """Used for performance reasons"""
@@ -59,3 +59,49 @@ class ConnValidType(IntEnum):
     """Invalid Connection due to different algorithm types (data or exec)"""
     DATA_MISSMATCH = auto()
     """Invalid Connection due to input / output Data type checking"""
+
+
+class ProgressState:
+    """
+    Represents a progress state / bar.
+    
+    A negative value indicates indefinite progress
+    """
+    
+    def __init__(self, max_value: Real = 1, value: Real = 0, message: str = ''):
+        self._max_value = max_value
+        self._value = value
+        self.message = message
+    
+    @property
+    def max_value(self):
+        """Max value of the progress."""
+        return self._max_value
+    
+    @max_value.setter
+    def max_value(self, max_value: Real):
+        self._max_value = max_value
+    
+    @property
+    def value(self):
+        """Current value of the progress. A negative value indicates indefinite progress"""
+        return self._value
+
+    @value.setter
+    def value(self, value: Real):
+        if value < 0:
+            self._value = value
+            return
+        
+        self._value = max(self._max_value, min(0, value))
+    
+    def is_indefinite(self) -> bool:
+        """Returns true if there is indefinite progress"""
+        return self._value < 0
+    
+    def percentage(self):
+        return self._value / self._max_value
+    
+    def as_percentage(self):
+        """Returns a new progress state so that max_value = 1"""
+        return ProgressState(1, self._value / self.max_value, self.message)

--- a/ryvencore/RC.py
+++ b/ryvencore/RC.py
@@ -1,6 +1,6 @@
 """Namespace for enum types etc."""
 
-from enum import IntEnum
+from enum import IntEnum, auto
 
 
 class FlowAlg(IntEnum):
@@ -40,3 +40,22 @@ class PortObjPos(IntEnum):
 
     INPUT = 1
     OUTPUT = 2
+
+
+class ConnValidType(IntEnum):
+    """
+    Result from a connection validity test between two node ports
+    """
+
+    VALID = auto()
+    """Valid Connection"""
+    SAME_NODE = auto()
+    """Invalid Connection due to same node"""
+    SAME_IO = auto()
+    """Invalid Connection due to both ports being input or output"""
+    IO_MISSMATCH = auto()
+    """Invalid Connection due to output being an input and vice-versa"""
+    DIFF_ALG_TYPE = auto()
+    """Invalid Connection due to different algorithm types (data or exec)"""
+    DATA_MISSMATCH = auto()
+    """Invalid Connection due to input / output not accepting the same family of Data"""

--- a/ryvencore/RC.py
+++ b/ryvencore/RC.py
@@ -58,4 +58,4 @@ class ConnValidType(IntEnum):
     DIFF_ALG_TYPE = auto()
     """Invalid Connection due to different algorithm types (data or exec)"""
     DATA_MISSMATCH = auto()
-    """Invalid Connection due to input / output not accepting the same family of Data"""
+    """Invalid Connection due to input / output Data type checking"""

--- a/ryvencore/RC.py
+++ b/ryvencore/RC.py
@@ -93,7 +93,6 @@ class ProgressState:
     __INDEFINITE_PROGRESS: int = -1
     
     @classmethod
-    @property
     def INDEFINITE_PROGRESS(cls):
         return cls.__INDEFINITE_PROGRESS
     
@@ -101,6 +100,9 @@ class ProgressState:
         self._max_value = max_value
         self._value = value
         self.message = message
+    
+    def __str__(self) -> str:
+        return f'Value:{self._value} Max:{self._max_value} Message: {self.message}'
     
     @property
     def max_value(self):
@@ -122,7 +124,7 @@ class ProgressState:
             self._value = value
             return
         
-        self._value = max(self._max_value, min(0, value))
+        self._value = min(value, self._max_value)
     
     def is_indefinite(self) -> bool:
         """Returns true if there is indefinite progress"""

--- a/ryvencore/Session.py
+++ b/ryvencore/Session.py
@@ -1,7 +1,7 @@
 import importlib
 import glob
 import os.path
-from typing import List, Dict, Type, Optional
+from typing import List, Dict, Type, Optional, Set
 
 from .Data import Data
 from .Base import Base, Event
@@ -33,10 +33,10 @@ class Session(Base):
 
         # ATTRIBUTES
         self.addons = {}
-        self.flows: [Flow] = []
-        self.nodes = set()      # list of node CLASSES
+        self.flows: List[Flow] = []
+        self.nodes: Set[Type[Node]] = set()      # list of node CLASSES
         self.invisible_nodes = set()
-        self.data_types = {}
+        self.data_types: Dict[Data] = {}
         self.gui: bool = gui
         self.init_data = None
 

--- a/ryvencore/Session.py
+++ b/ryvencore/Session.py
@@ -3,7 +3,8 @@ import glob
 import os.path
 from typing import List, Dict, Type, Optional, Set
 
-from .Data import Data
+from .data import Data 
+from .data.built_in import get_built_in_data_types 
 from .Base import Base, Event
 from .Flow import Flow
 from .InfoMsgs import InfoMsgs
@@ -35,11 +36,14 @@ class Session(Base):
         self.addons = {}
         self.flows: List[Flow] = []
         self.nodes: Set[Type[Node]] = set()      # list of node CLASSES
-        self.invisible_nodes = set()
-        self.data_types: Dict[Data] = {}
+        self.invisible_nodes: Set[Type[Node]] = set()
+        self.data_types: Dict[str, Type[Data]] = {}
         self.gui: bool = gui
         self.init_data = None
 
+        # Register Built-In Data Types
+        self.register_data_types(get_built_in_data_types())
+        
         # self.register_addons(pkg_path('addons/legacy/'))
         # self.register_addons(pkg_path('addons/'))
         if load_addons:
@@ -146,7 +150,24 @@ class Session(Base):
         for d in data_type_classes:
             self.register_data_type(d)
 
-
+    
+    def register_data_types_by_base(self, base_type: Type[Data]):
+        """
+        Registers :code:`Data` subclasses that belong to a base class.
+        """
+        
+        self.register_data_type(base_type)
+        for data_type in base_type.__subclasses__():
+            self.register_data_type(data_type)
+            
+    
+    def get_data_type(self, id: str) -> Optional[Type[Data]]:
+        """
+        Retrieves a data type with a specific id, if it exists
+        """
+        
+        return self.data_types.get(id)
+        
     def create_flow(self, title: str = None, data: Dict = None) -> Flow:
         """
         Creates and returns a new flow.

--- a/ryvencore/Session.py
+++ b/ryvencore/Session.py
@@ -132,7 +132,6 @@ class Session(Base):
         """
 
         data_type_class._build_identifier()
-        data_type_class.register_payload_type()
         
         id = data_type_class.identifier
         if id == 'Data' or id in self.data_types:

--- a/ryvencore/Session.py
+++ b/ryvencore/Session.py
@@ -1,7 +1,7 @@
 import importlib
 import glob
 import os.path
-from typing import List, Dict, Type, Optional, Set
+from typing import List, Dict, Type, Optional, Set, TYPE_CHECKING
 
 from .data import Data 
 from .data.built_in import get_built_in_data_types 
@@ -11,7 +11,9 @@ from .InfoMsgs import InfoMsgs
 from .utils import pkg_version, pkg_path, load_from_file, print_err
 from .Node import Node
 
-
+if TYPE_CHECKING:
+    from AddOn import AddOn
+    
 class Session(Base):
     """
     The Session is the top level interface to your project. It mainly manages flows, nodes, and add-ons and
@@ -33,7 +35,7 @@ class Session(Base):
         self.flow_deleted = Event(Flow)
 
         # ATTRIBUTES
-        self.addons = {}
+        self.addons: Dict[str, AddOn] = {}
         self.flows: List[Flow] = []
         self.nodes: Set[Type[Node]] = set()      # list of node CLASSES
         self.invisible_nodes: Set[Type[Node]] = set()

--- a/ryvencore/Session.py
+++ b/ryvencore/Session.py
@@ -1,7 +1,7 @@
 import importlib
 import glob
 import os.path
-from typing import List, Dict, Type, Optional, Set
+from typing import List, Dict, Type, Optional
 
 from .Data import Data
 from .Base import Base, Event
@@ -33,10 +33,10 @@ class Session(Base):
 
         # ATTRIBUTES
         self.addons = {}
-        self.flows: List[Flow] = []
-        self.nodes: Set[Type[Node]] = set()      # list of node CLASSES
+        self.flows: [Flow] = []
+        self.nodes = set()      # list of node CLASSES
         self.invisible_nodes = set()
-        self.data_types: Dict[Data] = {}
+        self.data_types = {}
         self.gui: bool = gui
         self.init_data = None
 

--- a/ryvencore/Session.py
+++ b/ryvencore/Session.py
@@ -130,6 +130,8 @@ class Session(Base):
         """
 
         data_type_class._build_identifier()
+        data_type_class.register_payload_type()
+        
         id = data_type_class.identifier
         if id == 'Data' or id in self.data_types:
             print_err(

--- a/ryvencore/__init__.py
+++ b/ryvencore/__init__.py
@@ -2,7 +2,7 @@ from .InfoMsgs import InfoMsgs
 from .RC import *
 from .Session import Session
 from .Flow import Flow
-from .data import Data
+from .data.Data import Data
 from .AddOn import AddOn
 from .Node import Node
 from .NodePortType import NodeInputType, NodeOutputType

--- a/ryvencore/__init__.py
+++ b/ryvencore/__init__.py
@@ -2,7 +2,7 @@ from .InfoMsgs import InfoMsgs
 from .RC import *
 from .Session import Session
 from .Flow import Flow
-from .Data import Data
+from .data import Data
 from .AddOn import AddOn
 from .Node import Node
 from .NodePortType import NodeInputType, NodeOutputType

--- a/ryvencore/addons/legacy/DTypes.py
+++ b/ryvencore/addons/legacy/DTypes.py
@@ -223,7 +223,7 @@ class DtypesAddon(AddOn):
                 self.dtype_inputs[inp] = dtype
 
     def extend_node_data(self, node, data: dict):
-        for i, inp in enumerate(node.inputs):
+        for i, inp in enumerate(node._inputs):
             if inp in self.dtype_inputs:
                 data['inputs'][i]['dtype'] = {
                     'type': str(self.dtype_inputs[inp]),

--- a/ryvencore/data/Data.py
+++ b/ryvencore/data/Data.py
@@ -4,11 +4,10 @@ It should be subclassed to define custom data types. In particular, serializatio
 and deserialization must be implemented for each respective type. Types that are
 pickle serializable by default can be used directly with :code`Data(my_data)`.
 """
-from typing import Dict, Type, Iterable, Set
+from typing import Dict, Type
 
 from ..Base import Base
 from ..utils import serialize, deserialize, print_err
-from types import MappingProxyType
 
 class Data(Base):
     """
@@ -92,15 +91,6 @@ class Data(Base):
     @classmethod
     def _build_identifier(cls):
         cls.identifier = cls.__name__
-
-    @classmethod
-    def register_payload_type(cls):
-        """
-        *VIRTUAL*
-        
-        Override this class method to register a payload type to a data type
-        """
-        pass
     
     def __init__(self, value=None, load_from=None):
         super().__init__()
@@ -185,28 +175,5 @@ def check_valid_data(out_data_type: Type[Data], inp_data_type: Type[Data]) -> bo
         out_data_type = Data
     
     return issubclass(out_data_type, inp_data_type)
-
-# dictionaries that associate payload to data
-__payload_to_data: Dict[type, Data] = {}
-__data_to_payload: Dict[Data, type] = {}
-
-payload_to_data = MappingProxyType(__payload_to_data)
-"""Maps payload types to data types"""
-
-data_to_payload = MappingProxyType(__data_to_payload)
-"""Inverse of payload_to_data"""
-
-def register_payload_to_data(payload_type: type, data_type: Data):
-    """Associates a payload type to a data type"""
-    
-    assert issubclass(data_type, Data), "Argument data_type must be of type Data"
-    
-    __payload_to_data[payload_type] = data_type
-    __data_to_payload[data_type] = payload_type
-
-def register_payload_to_data_multi(assoc_dict: Dict[type, Data]):
-    
-    for payload_type, data_type in assoc_dict.items():
-        register_payload_to_data(payload_type, data_type)
  
 

--- a/ryvencore/data/Data.py
+++ b/ryvencore/data/Data.py
@@ -167,7 +167,7 @@ class _BuiltInData(Data):
     
     @classmethod
     def _build_identifier(cls):
-        cls.identifier = f'data.built_in.{cls.__name__}'
+        cls.identifier = f'built_in.{cls.__name__}'
 
 _BuiltInData._build_identifier()
 

--- a/ryvencore/data/Data.py
+++ b/ryvencore/data/Data.py
@@ -4,11 +4,10 @@ It should be subclassed to define custom data types. In particular, serializatio
 and deserialization must be implemented for each respective type. Types that are
 pickle serializable by default can be used directly with :code`Data(my_data)`.
 """
-from typing import Dict, Type
+from typing import Dict, Type, Iterable, Set
 
-from ryvencore.Base import Base
-from ryvencore.utils import serialize, deserialize, print_err
-
+from ..Base import Base
+from ..utils import serialize, deserialize, print_err
 
 class Data(Base):
     """
@@ -80,7 +79,7 @@ class Data(Base):
     [1, 2, 3, 4]
     [1, 2, 3, 4]
     """
-
+    
     # will be 'Data' by default, see :code:`_build_identifier()`
     identifier: str = None
     """unique Data identifier; you can set this manually in subclasses, if
@@ -88,7 +87,7 @@ class Data(Base):
 
     legacy_identifiers = []
     """a list of compatible identifiers in case you change the identifier"""
-
+    
     @classmethod
     def _build_identifier(cls):
         cls.identifier = cls.__name__
@@ -99,8 +98,8 @@ class Data(Base):
         if load_from is not None:
             self.load(load_from)
         else:
-            self._payload = value
-
+            self.payload = value
+                
     def __str__(self):
         return f'<{self.__class__.__name__}({self.payload}) object, GID: {self.global_id}>'
 
@@ -149,6 +148,19 @@ class Data(Base):
 
         self.set_data(deserialize(data['serialized']))
 
+# build identifier for Data
+Data._build_identifier()
+
+
+class _BuiltInData(Data):
+    """Identifier type for built-in data types"""
+    
+    @classmethod
+    def _build_identifier(cls):
+        cls.identifier = f'data.built_in.{cls.__name__}'
+
+_BuiltInData._build_identifier()
+
 
 def check_valid_data(out_data_type: Type[Data], inp_data_type: Type[Data]) -> bool:
     """Returns true if input data can accept the output data, otherwise false"""
@@ -157,7 +169,5 @@ def check_valid_data(out_data_type: Type[Data], inp_data_type: Type[Data]) -> bo
         return True
     
     return issubclass(out_data_type, inp_data_type) 
-    
-    
-# build identifier for Data
-Data._build_identifier()
+
+

--- a/ryvencore/data/Data.py
+++ b/ryvencore/data/Data.py
@@ -8,6 +8,7 @@ from typing import Dict, Type, Iterable, Set
 
 from ..Base import Base
 from ..utils import serialize, deserialize, print_err
+from types import MappingProxyType
 
 class Data(Base):
     """
@@ -92,6 +93,15 @@ class Data(Base):
     def _build_identifier(cls):
         cls.identifier = cls.__name__
 
+    @classmethod
+    def register_payload_type(cls):
+        """
+        *VIRTUAL*
+        
+        Override this class method to register a payload type to a data type
+        """
+        pass
+    
     def __init__(self, value=None, load_from=None):
         super().__init__()
 
@@ -168,6 +178,29 @@ def check_valid_data(out_data_type: Type[Data], inp_data_type: Type[Data]) -> bo
     if inp_data_type is None or out_data_type is Data:
         return True
     
-    return issubclass(out_data_type, inp_data_type) 
+    return issubclass(out_data_type, inp_data_type)
 
+# dictionaries that associate payload to data
+__payload_to_data: Dict[type, Data] = {}
+__data_to_payload: Dict[Data, type] = {}
+
+payload_to_data = MappingProxyType(__payload_to_data)
+"""Maps payload types to data types"""
+
+data_to_payload = MappingProxyType(__data_to_payload)
+"""Inverse of payload_to_data"""
+
+def register_payload_to_data(payload_type: type, data_type: Data):
+    """Associates a payload type to a data type"""
+    
+    assert issubclass(data_type, Data), "Argument data_type must be of type Data"
+    
+    __payload_to_data[payload_type] = data_type
+    __data_to_payload[data_type] = payload_type
+
+def register_payload_to_data_multi(assoc_dict: Dict[type, Data]):
+    
+    for payload_type, data_type in assoc_dict.items():
+        register_payload_to_data(payload_type, data_type)
+ 
 

--- a/ryvencore/data/Data.py
+++ b/ryvencore/data/Data.py
@@ -173,10 +173,16 @@ _BuiltInData._build_identifier()
 
 
 def check_valid_data(out_data_type: Type[Data], inp_data_type: Type[Data]) -> bool:
-    """Returns true if input data can accept the output data, otherwise false"""
+    """
+    Returns true if input data can accept the output data, otherwise false
     
-    if inp_data_type is None or out_data_type is Data:
-        return True
+    None type is treated as the default Data type
+    """
+    
+    if inp_data_type is None:
+        inp_data_type = Data
+    if out_data_type is None:
+        out_data_type = Data
     
     return issubclass(out_data_type, inp_data_type)
 

--- a/ryvencore/data/__init__.py
+++ b/ryvencore/data/__init__.py
@@ -1,0 +1,1 @@
+from .Data import Data, check_valid_data

--- a/ryvencore/data/built_in/__init__.py
+++ b/ryvencore/data/built_in/__init__.py
@@ -1,0 +1,12 @@
+from .core import PayloadData, StringData, BytesData, get_built_in_data_types
+from .numbers import NumberData, ComplexData, RealData, RationalData, IntegerData
+from .collections.data_types import (
+    ListData,
+    TupleData,
+    DictData,
+    OrderedDictData,
+    SetData,
+    FrozenSetData,
+    QueueData,
+)
+

--- a/ryvencore/data/built_in/collections/abc.py
+++ b/ryvencore/data/built_in/collections/abc.py
@@ -1,0 +1,94 @@
+"""Defines abstract structure data types akin to collections.abc"""
+
+from ...Data import _BuiltInData
+from collections.abc import (
+    Container,
+    Hashable,
+    Iterable,
+    Iterator,
+    Reversible,
+    Generator,
+    Sized,
+    Collection,
+    Sequence,
+    MutableSequence,
+    Set,
+    MutableSet,
+    Mapping,
+    MutableMapping,
+    MappingView,
+    ItemsView,
+    KeysView,
+    ValuesView,
+)
+
+class _BaseStructureData(_BuiltInData):
+    """Base class for any collection"""
+    
+    collection_type = None
+    """Type from collections module that the payload must conform to"""
+
+    @property
+    def payload(self) -> collection_type:
+        return self._payload
+    
+    @payload.setter
+    def payload(self, value):
+        assert isinstance(value, self.collection_type), f'Payload of type {value.__class__} is not of (sub)type {self.collection_type.__class__}'
+        self._payload = value
+        
+class ContainerData(_BaseStructureData):
+    collection_type = Container
+
+class HashableData(_BaseStructureData):
+    collection_type = Hashable
+
+class IterableData(_BaseStructureData):
+    collection_type = Iterable
+
+class IteratorData(IterableData):
+    collection_type = Iterator
+
+class ReversibleData(IterableData):
+    collection_type = Reversible
+
+class GeneratorData(IteratorData):
+    collection_type = Generator
+
+class SizedData(_BuiltInData):
+    collection_type = Sized
+
+class CollectionData(SizedData, IterableData, ContainerData):
+    collection_type = Collection
+
+class SequenceData(ReversibleData, CollectionData):
+    collection_type = Sequence
+
+class MutableSequenceData(SequenceData):
+    collection_type = MutableSequence
+
+class SetData_ABC(CollectionData):
+    collection_type = Set
+
+class MutableSetData(SetData_ABC):
+    collection_type = MutableSet
+
+class MappingData(CollectionData):
+    collection_type = Mapping
+
+class MutableMappingData(MappingData):
+    collection_type = MutableMapping
+
+class MappingViewData(SizedData):
+    collection_type = MappingView
+
+class ItemsViewData(MappingViewData, SetData_ABC):
+    collection_type = ItemsView
+
+class KeysViewData(MappingView, Set):
+    collection_type = KeysView
+    
+class ValuesViewData(MappingViewData, CollectionData):
+    collection_type = ValuesView
+
+    

--- a/ryvencore/data/built_in/collections/data_types.py
+++ b/ryvencore/data/built_in/collections/data_types.py
@@ -9,6 +9,7 @@ from .abc import (
     SetData_ABC,
 )
 from collections import OrderedDict, deque
+from ...Data import register_payload_to_data_multi
 
 class ListData(MutableSequenceData):
     collection_type = list
@@ -16,7 +17,7 @@ class ListData(MutableSequenceData):
 class TupleData(SequenceData):
     collection_type = tuple
 
-class DictData(MappingData):
+class DictData(MutableMappingData):
     collection_type = dict
 
 class OrderedDictData(MutableMappingData):
@@ -30,6 +31,18 @@ class FrozenSetData(SetData_ABC):
 
 class QueueData(MutableSequenceData):
     collection_type = deque
+
+register_payload_to_data_multi(
+    {
+        list: ListData,
+        tuple: TupleData,
+        dict: DictData,
+        OrderedDict: OrderedDictData,
+        set: SetData,
+        frozenset: FrozenSetData,
+        deque: QueueData,
+    }
+)
 
 
 

--- a/ryvencore/data/built_in/collections/data_types.py
+++ b/ryvencore/data/built_in/collections/data_types.py
@@ -1,0 +1,35 @@
+"""Defines implemented structure data types found in Python's Standard Library"""
+
+from .abc import (
+    MutableSequenceData,
+    SequenceData,
+    MappingData,
+    MutableMappingData,
+    MutableSetData,
+    SetData_ABC,
+)
+from collections import OrderedDict, deque
+
+class ListData(MutableSequenceData):
+    collection_type = list
+
+class TupleData(SequenceData):
+    collection_type = tuple
+
+class DictData(MappingData):
+    collection_type = dict
+
+class OrderedDictData(MutableMappingData):
+    collection_type = OrderedDict
+
+class SetData(MutableSetData):
+    collection_type = set
+
+class FrozenSetData(SetData_ABC):
+    collection_type = frozenset
+
+class QueueData(MutableSequenceData):
+    collection_type = deque
+
+
+

--- a/ryvencore/data/built_in/collections/data_types.py
+++ b/ryvencore/data/built_in/collections/data_types.py
@@ -9,7 +9,6 @@ from .abc import (
     SetData_ABC,
 )
 from collections import OrderedDict, deque
-from ...Data import register_payload_to_data_multi
 
 class ListData(MutableSequenceData):
     collection_type = list
@@ -32,17 +31,6 @@ class FrozenSetData(SetData_ABC):
 class QueueData(MutableSequenceData):
     collection_type = deque
 
-register_payload_to_data_multi(
-    {
-        list: ListData,
-        tuple: TupleData,
-        dict: DictData,
-        OrderedDict: OrderedDictData,
-        set: SetData,
-        frozenset: FrozenSetData,
-        deque: QueueData,
-    }
-)
 
 
 

--- a/ryvencore/data/built_in/core.py
+++ b/ryvencore/data/built_in/core.py
@@ -1,6 +1,6 @@
 """Defines common data types based on python standard types"""
 
-from ..Data import Data, _BuiltInData, register_payload_to_data
+from ..Data import Data, _BuiltInData
 from typing import Iterable
 from .collections.abc import SequenceData
  
@@ -16,11 +16,6 @@ class PayloadData(_BuiltInData):
     Not used for type-checking
     """
     
-    @classmethod
-    def register_payload_type(cls):
-        if cls.payload_type:
-            register_payload_to_data(cls.payload_type, cls)
-    
     def __init__(self, value=None, load_from=None):
         super().__init__(value, load_from)
         
@@ -32,12 +27,8 @@ class PayloadData(_BuiltInData):
 class StringData(SequenceData):
     collection_type = str
 
-register_payload_to_data(str, StringData)
-
 class BytesData(SequenceData):
     collection_type = bytes
- 
-register_payload_to_data(bytes, BytesData)
 
 def __get_all_subclasses(cls):
     subclasses = set(cls.__subclasses__())

--- a/ryvencore/data/built_in/core.py
+++ b/ryvencore/data/built_in/core.py
@@ -1,6 +1,6 @@
 """Defines common data types based on python standard types"""
 
-from ..Data import Data, _BuiltInData
+from ..Data import Data, _BuiltInData, register_payload_to_data
 from typing import Iterable
 from .collections.abc import SequenceData
  
@@ -14,7 +14,12 @@ class PayloadData(_BuiltInData):
     """
     Type used to assert that the value is a (sub)class of that type
     Not used for type-checking
-    """  
+    """
+    
+    @classmethod
+    def register_payload_type(cls):
+        if cls.payload_type:
+            register_payload_to_data(cls.payload_type, cls)
     
     def __init__(self, value=None, load_from=None):
         super().__init__(value, load_from)
@@ -27,10 +32,12 @@ class PayloadData(_BuiltInData):
 class StringData(SequenceData):
     collection_type = str
 
+register_payload_to_data(str, StringData)
 
 class BytesData(SequenceData):
     collection_type = bytes
  
+register_payload_to_data(bytes, BytesData)
 
 def __get_all_subclasses(cls):
     subclasses = set(cls.__subclasses__())

--- a/ryvencore/data/built_in/core.py
+++ b/ryvencore/data/built_in/core.py
@@ -1,0 +1,44 @@
+"""Defines common data types based on python standard types"""
+
+from ..Data import Data, _BuiltInData
+from typing import Iterable
+from .collections.abc import SequenceData
+ 
+class PayloadData(_BuiltInData):
+    """
+    Data container that checks if the appropriate payload type has been set
+    on instantiation.
+    """
+    
+    payload_type = None
+    """
+    Type used to assert that the value is a (sub)class of that type
+    Not used for type-checking
+    """  
+    
+    def __init__(self, value=None, load_from=None):
+        super().__init__(value, load_from)
+        
+        # payload initialization if a type is given and the value is not of that type
+        if (self.payload_type is not None and self._payload is not None):
+            assert isinstance(self._payload, self.payload_type), f'Payload {self._payload} does not inherit from {self.payload_type}'
+            
+
+class StringData(SequenceData):
+    collection_type = str
+
+
+class BytesData(SequenceData):
+    collection_type = bytes
+ 
+
+def __get_all_subclasses(cls):
+    subclasses = set(cls.__subclasses__())
+    for subclass in cls.__subclasses__():
+        subclasses.update(__get_all_subclasses(subclass))
+    return subclasses 
+
+
+def get_built_in_data_types() -> Iterable[Data]:
+    """Retrieves all the built-in data types"""
+    return __get_all_subclasses(_BuiltInData)

--- a/ryvencore/data/built_in/numbers.py
+++ b/ryvencore/data/built_in/numbers.py
@@ -1,6 +1,6 @@
 """Defines basic numeric data types"""
 
-from ..Data import _BuiltInData, register_payload_to_data
+from ..Data import _BuiltInData
 from numbers import Number, Complex, Real, Rational, Integral
 from fractions import Fraction
 
@@ -12,10 +12,6 @@ class NumberData(_BuiltInData):
     
     fallback_type = None
     """Fallback type to attempt instantiation if the value is not of number_type"""
-    
-    @classmethod
-    def register_payload_type(cls):
-        register_payload_to_data(cls.fallback_type, cls)
     
     def __init__(self, value: number_type, load_from=None):
         super().__init__(value, load_from)

--- a/ryvencore/data/built_in/numbers.py
+++ b/ryvencore/data/built_in/numbers.py
@@ -1,6 +1,6 @@
 """Defines basic numeric data types"""
 
-from ..Data import _BuiltInData
+from ..Data import _BuiltInData, register_payload_to_data
 from numbers import Number, Complex, Real, Rational, Integral
 from fractions import Fraction
 
@@ -13,7 +13,10 @@ class NumberData(_BuiltInData):
     fallback_type = None
     """Fallback type to attempt instantiation if the value is not of number_type"""
     
-    # value: Number can be replaced by value: number_type in 3.10+
+    @classmethod
+    def register_payload_type(cls):
+        register_payload_to_data(cls.fallback_type, cls)
+    
     def __init__(self, value: number_type, load_from=None):
         super().__init__(value, load_from)
     

--- a/ryvencore/data/built_in/numbers.py
+++ b/ryvencore/data/built_in/numbers.py
@@ -1,0 +1,47 @@
+"""Defines basic numeric data types"""
+
+from ..Data import _BuiltInData
+from numbers import Number, Complex, Real, Rational, Integral
+from fractions import Fraction
+
+class NumberData(_BuiltInData):
+    """Base data class for numbers"""
+    
+    number_type = Number
+    """Type from numbers module that the payload must conform to"""
+    
+    fallback_type = None
+    """Fallback type to attempt instantiation if the value is not of number_type"""
+    
+    # value: Number can be replaced by value: number_type in 3.10+
+    def __init__(self, value: number_type, load_from=None):
+        super().__init__(value, load_from)
+    
+    @property
+    def payload(self) -> number_type:
+        return self._payload
+    
+    @payload.setter
+    def payload(self, value: number_type):
+        assert isinstance(value, self.number_type), f'Payload of type {value.__class__} is not of (sub)type {self.number_type.__class__}'
+
+        self._payload = value
+        # Attempt to cast the given value to the fallback type
+        if self.fallback_type is not None and self._payload.__class__ is not self.fallback_type:
+            self._payload = self.fallback_type(self._payload)
+                      
+class ComplexData(NumberData):
+    number_type = Complex
+    fallback_type = complex
+    
+class RealData(ComplexData):
+    number_type = Real
+    fallback_type = float
+    
+class RationalData(RealData):
+    number_type = Rational
+    fallback_type = Fraction
+    
+class IntegerData(RationalData):
+    number_type = Integral
+    fallback_type = int 

--- a/ryvencore/utils.py
+++ b/ryvencore/utils.py
@@ -5,8 +5,11 @@ import json
 import pickle
 import sys
 from os.path import dirname, abspath, join, basename
-from typing import List, Tuple, Optional, Dict
+from typing import List, Tuple, Optional, Dict, Type
 from packaging.version import Version, parse as _parse_version
+from .RC import ConnValidType, PortObjPos
+from .NodePort import NodePort, NodeInput, NodeOutput
+from .Data import Data, check_valid_data
 import importlib.util
 
 if sys.version_info < (3, 8):
@@ -90,3 +93,37 @@ def load_from_file(file: str, comps: List[str]) -> Tuple:
             return None
 
     return tuple([get_comp(c) for c in comps])
+
+
+def check_valid_conn(out: NodeOutput, inp: NodeInput) -> Tuple[ConnValidType, str]:
+    """
+    Checks if a connection is valid between two node ports.
+
+    Returns:
+        A tuple with the result of the check and a detailed reason, if it exists.
+    """
+    
+    if out.node == inp.node:
+        return (ConnValidType.SAME_NODE, "Ports from the same node cannot be connected!")
+    
+    if out.io_pos == inp.io_pos:
+        return (ConnValidType.SAME_IO, "Connections cannot be made between ports of the same pos (inp-inp) or (out-out)")
+    
+    if out.io_pos != PortObjPos.OUTPUT:
+        return (ConnValidType.IO_MISSMATCH, f"Output io_pos should be {PortObjPos.OUTPUT} but instead is {out.io_pos}")
+    
+    if out.type_ != inp.type_:
+        return (ConnValidType.DIFF_ALG_TYPE, "Input and output must both be either exec ports or data ports")
+    
+    if not check_valid_data(out.allowed_data, inp.allowed_data):
+        return (ConnValidType.DATA_MISSMATCH, 
+                f"When input type is defined, output type must be a (sub)class of input type\n [out={out.allowed_data}, inp={inp.allowed_data}]")
+    
+    return (ConnValidType.VALID, "Connection is valid!")
+
+
+def check_valid_conn_tuple(connection: Tuple[NodeOutput, NodeInput]):
+    out, inp = connection
+    return check_valid_conn(out, inp)
+
+    

--- a/tests/data_flow.py
+++ b/tests/data_flow.py
@@ -24,7 +24,7 @@ class Node2(NodeBase):
     init_outputs = []
 
     def update_event(self, inp=-1):
-        print(f'received data on input {inp}: {self.input_value(inp)}')
+        print(f'received data on input {inp}: {self.input(inp)}')
 
 
 class DataFlowBasic(unittest.TestCase):
@@ -55,7 +55,7 @@ class DataFlowBasic(unittest.TestCase):
 
         self.assertEqual(n1.outputs[0].val.payload, 'Hello, World!')
         self.assertEqual(n1.outputs[1].val.payload, 42)
-        self.assertEqual(n3.input_value(0), n4.input_value(0))
+        self.assertEqual(n3.input(0), n4.input(0))
 
         # test save and load
 
@@ -70,9 +70,9 @@ class DataFlowBasic(unittest.TestCase):
 
         n1_2, n2_2, n3_2, n4_2 = f2.nodes
 
-        assert n2_2.input_value(0).payload == 'Hello, World!'
-        assert n3_2.input_value(0).payload == 42
-        assert n4_2.input_value(0).payload == 42
+        assert n2_2.input(0).payload == 'Hello, World!'
+        assert n3_2.input(0).payload == 42
+        assert n4_2.input(0).payload == 42
 
         n1_2.update()
 

--- a/tests/data_flow.py
+++ b/tests/data_flow.py
@@ -24,7 +24,7 @@ class Node2(NodeBase):
     init_outputs = []
 
     def update_event(self, inp=-1):
-        print(f'received data on input {inp}: {self.input(inp)}')
+        print(f'received data on input {inp}: {self.input_value(inp)}')
 
 
 class DataFlowBasic(unittest.TestCase):
@@ -55,7 +55,7 @@ class DataFlowBasic(unittest.TestCase):
 
         self.assertEqual(n1.outputs[0].val.payload, 'Hello, World!')
         self.assertEqual(n1.outputs[1].val.payload, 42)
-        self.assertEqual(n3.input(0), n4.input(0))
+        self.assertEqual(n3.input_value(0), n4.input_value(0))
 
         # test save and load
 
@@ -70,9 +70,9 @@ class DataFlowBasic(unittest.TestCase):
 
         n1_2, n2_2, n3_2, n4_2 = f2.nodes
 
-        assert n2_2.input(0).payload == 'Hello, World!'
-        assert n3_2.input(0).payload == 42
-        assert n4_2.input(0).payload == 42
+        assert n2_2.input_value(0).payload == 'Hello, World!'
+        assert n3_2.input_value(0).payload == 42
+        assert n4_2.input_value(0).payload == 42
 
         n1_2.update()
 

--- a/tests/data_flow.py
+++ b/tests/data_flow.py
@@ -42,19 +42,19 @@ class DataFlowBasic(unittest.TestCase):
 
         n2.update()
 
-        f.connect_nodes(n1.outputs[0], n2.inputs[0])
-        f.connect_nodes(n1.outputs[1], n3.inputs[0])
-        f.connect_nodes(n1.outputs[1], n4.inputs[0])
+        f.connect_nodes(n1._outputs[0], n2._inputs[0])
+        f.connect_nodes(n1._outputs[1], n3._inputs[0])
+        f.connect_nodes(n1._outputs[1], n4._inputs[0])
 
         # test data model
 
-        self.assertEqual(n1.outputs[0].val, None)
-        self.assertEqual(n1.outputs[1].val, None)
+        self.assertEqual(n1._outputs[0].val, None)
+        self.assertEqual(n1._outputs[1].val, None)
 
         n1.update()
 
-        self.assertEqual(n1.outputs[0].val.payload, 'Hello, World!')
-        self.assertEqual(n1.outputs[1].val.payload, 42)
+        self.assertEqual(n1._outputs[0].val.payload, 'Hello, World!')
+        self.assertEqual(n1._outputs[1].val.payload, 42)
         self.assertEqual(n3.input(0), n4.input(0))
 
         # test save and load

--- a/tests/data_objects.py
+++ b/tests/data_objects.py
@@ -130,6 +130,11 @@ class DataTypesBuiltIn(unittest.TestCase):
         self.assertIsNotNone(f.connect_nodes(n1.outputs[0], n2.inputs[0])) # ComplexData -> NumberData should be ok
         self.assertIsNone(f.connect_nodes(n1.outputs[0], n2.inputs[1])) # ComplexData -> ListData should not be ok
         
+        n1.set_output_payload(0, 23.0)
+        self.assertTrue(n2.input_payload(0) == 23)
+        self.assertTrue(isinstance(n2.input(0), ComplexData))
+        self.assertFalse(isinstance(n2.input(0), IntegerData))
+
         
 if __name__ == '__main__':
     unittest.main()

--- a/tests/data_objects.py
+++ b/tests/data_objects.py
@@ -134,7 +134,7 @@ class DataTypesBuiltIn(unittest.TestCase):
         self.assertIsNotNone(f.connect_nodes(n1._outputs[0], n2._inputs[0])) # ComplexData -> NumberData should be ok
         self.assertIsNone(f.connect_nodes(n1._outputs[0], n2._inputs[1])) # ComplexData -> ListData should not be ok
         
-        n1.set_output_payload(0, 23.0) # automatic data type detection
+        n1.set_output_val(0, RealData(23.0))
         self.assertTrue(n2.input_payload(0) == 23)
         self.assertTrue(isinstance(n2.input(0), ComplexData))
         self.assertFalse(isinstance(n2.input(0), IntegerData))
@@ -142,7 +142,7 @@ class DataTypesBuiltIn(unittest.TestCase):
         self.assertIsNotNone(f.connect_nodes(n1._outputs[1], n2._inputs[1])) # ListData -> ListData should be ok
         self.assertIsNotNone(f.connect_nodes(n1._outputs[1], n2._inputs[2])) # ListData -> SequenceData should be ok 
         
-        n1.set_output_payload(1, [1, 2, 3])
+        n1.set_output_val(1, ListData([1, 2, 3]))
         self.assertTrue(isinstance(n2.input(1), ListData))
 
         

--- a/tests/data_objects.py
+++ b/tests/data_objects.py
@@ -19,7 +19,7 @@ class DataTypesBasic(unittest.TestCase):
             self.x = None
 
         def update_event(self, inp=-1):
-            self.x = self.input(0).payload
+            self.x = self.input_value(0).payload
 
     def runTest(self):
         s = rc.Session()
@@ -60,7 +60,7 @@ class DataTypesCustom(unittest.TestCase):
             self.x = None
 
         def update_event(self, inp=-1):
-            self.x = self.input(0).payload
+            self.x = self.input_value(0).payload
 
     def runTest(self):
         s = rc.Session()

--- a/tests/data_objects.py
+++ b/tests/data_objects.py
@@ -3,7 +3,7 @@ import ryvencore as rc
 
 from ryvencore.data.built_in import *
 from ryvencore.data.built_in.collections.abc import *
-from ryvencore.data.Data import check_valid_data
+from ryvencore.data import Data, check_valid_data
 from ryvencore.NodePort import check_valid_conn
 
 class DataTypesBasic(unittest.TestCase):
@@ -129,6 +129,7 @@ class DataTypesBuiltIn(unittest.TestCase):
         
         self.assertIsNotNone(f.connect_nodes(n1.outputs[0], n2.inputs[0])) # ComplexData -> NumberData should be ok
         self.assertIsNone(f.connect_nodes(n1.outputs[0], n2.inputs[1])) # ComplexData -> ListData should not be ok
+        
         
 if __name__ == '__main__':
     unittest.main()

--- a/tests/data_objects.py
+++ b/tests/data_objects.py
@@ -31,10 +31,10 @@ class DataTypesBasic(unittest.TestCase):
         f = s.create_flow('main')
         n1 = f.create_node(self.Producer)
         n2 = f.create_node(self.Consumer)
-        f.connect_nodes(n1.outputs[0], n2.inputs[0])
+        f.connect_nodes(n1._outputs[0], n2._inputs[0])
         n1.update()
 
-        self.assertTrue(isinstance(n1.outputs[0].val, rc.Data))
+        self.assertTrue(isinstance(n1._outputs[0].val, rc.Data))
         self.assertEqual(n2.x, 42)
 
 
@@ -73,10 +73,10 @@ class DataTypesCustom(unittest.TestCase):
         f = s.create_flow('main')
         n1 = f.create_node(self.Producer)
         n2 = f.create_node(self.Consumer)
-        f.connect_nodes(n1.outputs[0], n2.inputs[0])
+        f.connect_nodes(n1._outputs[0], n2._inputs[0])
         n1.update()
-        self.assertTrue(isinstance(n1.outputs[0].val, DataTypesCustom.MyData))
-        self.assertTrue(isinstance(n1.outputs[0].val, self.MyData))
+        self.assertTrue(isinstance(n1._outputs[0].val, DataTypesCustom.MyData))
+        self.assertTrue(isinstance(n1._outputs[0].val, self.MyData))
 
         project = s.serialize()
         rc.utils.json_print(project)
@@ -87,7 +87,7 @@ class DataTypesCustom(unittest.TestCase):
         s2.load(project)
         f2 = s2.flows[0]
         n2_1, n2_2 = f2.nodes
-        self.assertTrue(isinstance(n2_1.outputs[0].val, self.MyData))
+        self.assertTrue(isinstance(n2_1._outputs[0].val, self.MyData))
         n2_1.update()
         self.assertEqual(n2_2.x, 42)
 
@@ -131,16 +131,16 @@ class DataTypesBuiltIn(unittest.TestCase):
         n1 = f.create_node(self.Producer)
         n2 = f.create_node(self.Consumer)
         
-        self.assertIsNotNone(f.connect_nodes(n1.outputs[0], n2.inputs[0])) # ComplexData -> NumberData should be ok
-        self.assertIsNone(f.connect_nodes(n1.outputs[0], n2.inputs[1])) # ComplexData -> ListData should not be ok
+        self.assertIsNotNone(f.connect_nodes(n1._outputs[0], n2._inputs[0])) # ComplexData -> NumberData should be ok
+        self.assertIsNone(f.connect_nodes(n1._outputs[0], n2._inputs[1])) # ComplexData -> ListData should not be ok
         
         n1.set_output_payload(0, 23.0) # automatic data type detection
         self.assertTrue(n2.input_payload(0) == 23)
         self.assertTrue(isinstance(n2.input(0), ComplexData))
         self.assertFalse(isinstance(n2.input(0), IntegerData))
         
-        self.assertIsNotNone(f.connect_nodes(n1.outputs[1], n2.inputs[1])) # ListData -> ListData should be ok
-        self.assertIsNotNone(f.connect_nodes(n1.outputs[1], n2.inputs[2])) # ListData -> SequenceData should be ok 
+        self.assertIsNotNone(f.connect_nodes(n1._outputs[1], n2._inputs[1])) # ListData -> ListData should be ok
+        self.assertIsNotNone(f.connect_nodes(n1._outputs[1], n2._inputs[2])) # ListData -> SequenceData should be ok 
         
         n1.set_output_payload(1, [1, 2, 3])
         self.assertTrue(isinstance(n2.input(1), ListData))

--- a/tests/data_objects.py
+++ b/tests/data_objects.py
@@ -19,7 +19,7 @@ class DataTypesBasic(unittest.TestCase):
             self.x = None
 
         def update_event(self, inp=-1):
-            self.x = self.input_value(0).payload
+            self.x = self.input(0).payload
 
     def runTest(self):
         s = rc.Session()
@@ -60,7 +60,7 @@ class DataTypesCustom(unittest.TestCase):
             self.x = None
 
         def update_event(self, inp=-1):
-            self.x = self.input_value(0).payload
+            self.x = self.input(0).payload
 
     def runTest(self):
         s = rc.Session()

--- a/tests/data_objects.py
+++ b/tests/data_objects.py
@@ -95,15 +95,19 @@ class DataTypesCustom(unittest.TestCase):
 class DataTypesBuiltIn(unittest.TestCase):
     
     class Producer(rc.Node):
-        init_outputs = [rc.NodeOutputType(allowed_data=ComplexData)]
+        init_outputs = [
+            rc.NodeOutputType(allowed_data=ComplexData),
+            rc.NodeOutputType(allowed_data=ListData),
+        ]
 
         def update_event(self, inp=-1):
-            self.set_output_val(0, rc.Data(42))
+            self.set_output_payload(0, 42 + 2j)
 
     class Consumer(rc.Node):
         init_inputs = [
             rc.NodeInputType(allowed_data=NumberData),
             rc.NodeInputType(allowed_data=ListData),
+            rc.NodeInputType(allowed_data=SequenceData),
         ]
 
         def __init__(self, params):
@@ -130,10 +134,16 @@ class DataTypesBuiltIn(unittest.TestCase):
         self.assertIsNotNone(f.connect_nodes(n1.outputs[0], n2.inputs[0])) # ComplexData -> NumberData should be ok
         self.assertIsNone(f.connect_nodes(n1.outputs[0], n2.inputs[1])) # ComplexData -> ListData should not be ok
         
-        n1.set_output_payload(0, 23.0)
+        n1.set_output_payload(0, 23.0) # automatic data type detection
         self.assertTrue(n2.input_payload(0) == 23)
         self.assertTrue(isinstance(n2.input(0), ComplexData))
         self.assertFalse(isinstance(n2.input(0), IntegerData))
+        
+        self.assertIsNotNone(f.connect_nodes(n1.outputs[1], n2.inputs[1])) # ListData -> ListData should be ok
+        self.assertIsNotNone(f.connect_nodes(n1.outputs[1], n2.inputs[2])) # ListData -> SequenceData should be ok 
+        
+        n1.set_output_payload(1, [1, 2, 3])
+        self.assertTrue(isinstance(n2.input(1), ListData))
 
         
 if __name__ == '__main__':

--- a/tests/exec_flow.py
+++ b/tests/exec_flow.py
@@ -25,8 +25,8 @@ class Node2(rc.Node):
         self.data = None
 
     def update_event(self, inp=-1):
-        self.data = self.input_value(1).payload
-        print(f'received data on input {inp}: {self.input_value(inp)}')
+        self.data = self.input(1).payload
+        print(f'received data on input {inp}: {self.input(inp)}')
 
 
 class ExecFlowBasic(unittest.TestCase):

--- a/tests/exec_flow.py
+++ b/tests/exec_flow.py
@@ -25,8 +25,8 @@ class Node2(rc.Node):
         self.data = None
 
     def update_event(self, inp=-1):
-        self.data = self.input(1).payload
-        print(f'received data on input {inp}: {self.input(inp)}')
+        self.data = self.input_value(1).payload
+        print(f'received data on input {inp}: {self.input_value(inp)}')
 
 
 class ExecFlowBasic(unittest.TestCase):

--- a/tests/exec_flow.py
+++ b/tests/exec_flow.py
@@ -43,18 +43,18 @@ class ExecFlowBasic(unittest.TestCase):
         n3 = f.create_node(Node2)
         n4 = f.create_node(Node2)
 
-        f.connect_nodes(n1.outputs[0], n2.inputs[0])
-        f.connect_nodes(n1.outputs[1], n2.inputs[1])
-        f.connect_nodes(n1.outputs[0], n3.inputs[0])
-        f.connect_nodes(n1.outputs[1], n4.inputs[1])
+        f.connect_nodes(n1._outputs[0], n2._inputs[0])
+        f.connect_nodes(n1._outputs[1], n2._inputs[1])
+        f.connect_nodes(n1._outputs[0], n3._inputs[0])
+        f.connect_nodes(n1._outputs[1], n4._inputs[1])
 
-        self.assertEqual(n1.outputs[0].val, None)
-        self.assertEqual(n1.outputs[1].val, None)
+        self.assertEqual(n1._outputs[0].val, None)
+        self.assertEqual(n1._outputs[1].val, None)
 
         n1.update()
 
-        self.assertEqual(n1.outputs[0].val, None)
-        self.assertEqual(n1.outputs[1].val.payload, 'Hello, World!')
+        self.assertEqual(n1._outputs[0].val, None)
+        self.assertEqual(n1._outputs[1].val.payload, 'Hello, World!')
 
         self.assertEqual(n2.data, 'Hello, World!')
         self.assertEqual(n3.data, None)

--- a/tests/logging-addon.py
+++ b/tests/logging-addon.py
@@ -38,7 +38,7 @@ class Node2(NodeBase):
     init_outputs = []
 
     def update_event(self, inp=-1):
-        print(f'received data on input {inp}: {self.input(inp)}')
+        print(f'received data on input {inp}: {self.input_value(inp)}')
 
 
 class DataFlowBasic(unittest.TestCase):

--- a/tests/logging-addon.py
+++ b/tests/logging-addon.py
@@ -38,7 +38,7 @@ class Node2(NodeBase):
     init_outputs = []
 
     def update_event(self, inp=-1):
-        print(f'received data on input {inp}: {self.input_value(inp)}')
+        print(f'received data on input {inp}: {self.input(inp)}')
 
 
 class DataFlowBasic(unittest.TestCase):

--- a/tests/variables-addon.py
+++ b/tests/variables-addon.py
@@ -54,7 +54,7 @@ class Node2(NodeBase):
     init_outputs = []
 
     def update_event(self, inp=-1):
-        print(f'received data on input {inp}: {self.input_value(inp)}')
+        print(f'received data on input {inp}: {self.input(inp)}')
 
     def update_var1(self, val):
         self.Vars.var(self.flow, 'var1').set(val)
@@ -84,7 +84,7 @@ class VariablesBasic(unittest.TestCase):
 
         self.assertEqual(n1.outputs[0].val.payload, 'Hello, World!')
         self.assertEqual(n1.outputs[1].val.payload, 42)
-        self.assertEqual(n3.input_value(0), n4.input_value(0))
+        self.assertEqual(n3.input(0), n4.input(0))
 
         # test variables addon
 
@@ -113,8 +113,8 @@ class VariablesBasic(unittest.TestCase):
         n2_2.update_var1('test')
 
         self.assertEqual(n1_2.var_val.get(), 'test')
-        self.assertEqual(n3_2.input_value(0).payload, 42)
-        self.assertEqual(n4_2.input_value(0).payload, 42)
+        self.assertEqual(n3_2.input(0).payload, 42)
+        self.assertEqual(n4_2.input(0).payload, 42)
 
         n1_2.update()
         n2_2.update_var1(43)

--- a/tests/variables-addon.py
+++ b/tests/variables-addon.py
@@ -74,16 +74,16 @@ class VariablesBasic(unittest.TestCase):
         n3 = f.create_node(Node2)
         n4 = f.create_node(Node2)
 
-        f.connect_nodes(n1.outputs[0], n2.inputs[0])
-        f.connect_nodes(n1.outputs[1], n3.inputs[0])
-        f.connect_nodes(n1.outputs[1], n4.inputs[0])
+        f.connect_nodes(n1._outputs[0], n2._inputs[0])
+        f.connect_nodes(n1._outputs[1], n3._inputs[0])
+        f.connect_nodes(n1._outputs[1], n4._inputs[0])
 
         n1.create_var1()
 
         n1.update()
 
-        self.assertEqual(n1.outputs[0].val.payload, 'Hello, World!')
-        self.assertEqual(n1.outputs[1].val.payload, 42)
+        self.assertEqual(n1._outputs[0].val.payload, 'Hello, World!')
+        self.assertEqual(n1._outputs[1].val.payload, 42)
         self.assertEqual(n3.input(0), n4.input(0))
 
         # test variables addon

--- a/tests/variables-addon.py
+++ b/tests/variables-addon.py
@@ -54,7 +54,7 @@ class Node2(NodeBase):
     init_outputs = []
 
     def update_event(self, inp=-1):
-        print(f'received data on input {inp}: {self.input(inp)}')
+        print(f'received data on input {inp}: {self.input_value(inp)}')
 
     def update_var1(self, val):
         self.Vars.var(self.flow, 'var1').set(val)
@@ -84,7 +84,7 @@ class VariablesBasic(unittest.TestCase):
 
         self.assertEqual(n1.outputs[0].val.payload, 'Hello, World!')
         self.assertEqual(n1.outputs[1].val.payload, 42)
-        self.assertEqual(n3.input(0), n4.input(0))
+        self.assertEqual(n3.input_value(0), n4.input_value(0))
 
         # test variables addon
 
@@ -113,8 +113,8 @@ class VariablesBasic(unittest.TestCase):
         n2_2.update_var1('test')
 
         self.assertEqual(n1_2.var_val.get(), 'test')
-        self.assertEqual(n3_2.input(0).payload, 42)
-        self.assertEqual(n4_2.input(0).payload, 42)
+        self.assertEqual(n3_2.input_value(0).payload, 42)
+        self.assertEqual(n4_2.input_value(0).payload, 42)
 
         n1_2.update()
         n2_2.update_var1(43)


### PR DESCRIPTION
This PR includes type checking with the `Data` class when connecting nodes as well as when passing data between ports. It also includes some QoL changes. Specifically...

### Data and Type Checking

Due to various changes, a new folder / module named data has been introduced.

Type checking is done via a simple function defined in `Data.py`:

```python
def check_valid_data(out_data_type: Type[Data], inp_data_type: Type[Data]) -> bool:
    """
    Returns true if input data can accept the output data, otherwise false
    
    None type is treated as the default Data type
    """
    
    if inp_data_type is None:
        inp_data_type = Data
    if out_data_type is None:
        out_data_type = Data
    
    return issubclass(out_data_type, inp_data_type)
```

Another function is defined in `NodePort.py` for connection validity. It uses a new enum type defined in `RC.py`:
<details>
    <summary>Code</summary>

```python
def check_valid_conn(out: NodeOutput, inp: NodeInput) -> Tuple[ConnValidType, str]:
    """
    Checks if a connection is valid between two node ports.

    Returns:
        A tuple with the result of the check and a detailed reason, if it exists.
    """
    
    if out.node == inp.node:
        return (ConnValidType.SAME_NODE, "Ports from the same node cannot be connected!")
    
    if out.io_pos == inp.io_pos:
        return (ConnValidType.SAME_IO, "Connections cannot be made between ports of the same pos (inp-inp) or (out-out)")
    
    if out.io_pos != PortObjPos.OUTPUT:
        return (ConnValidType.IO_MISSMATCH, f"Output io_pos should be {PortObjPos.OUTPUT} but instead is {out.io_pos}")
    
    if out.type_ != inp.type_:
        return (ConnValidType.DIFF_ALG_TYPE, "Input and output must both be either exec ports or data ports")
    
    if not check_valid_data(out.allowed_data, inp.allowed_data):
        return (ConnValidType.DATA_MISSMATCH, 
                f"When input type is defined, output type must be a (sub)class of input type\n [out={out.allowed_data}, inp={inp.allowed_data}]")
    
    return (ConnValidType.VALID, "Connection is valid!")
```
</details>

As shown above, ports can be given an `allowed_data` in the constructor, which is serialized along with the port. Finally, setting an output value asserts for the correct type like this:

```python
out = self.outputs[index]
data_type = (out.allowed_data 
                     if out.allowed_data and issubclass(out.allowed_data, Data)
                     else Data) 
        
assert isinstance(data, data_type), f"Output value must be of type {data_type.__module__}.{data_type.__name__}"
```

Along with these, the PR includes a `_BuiltInData` type in `Data.py` for defining various built-in types associated with payload types of the python standard library. Types from a specific parent class can be searched using `get_built_in_data_types` defined in `core.py`. The built-in types are automatically registered when a `Session` is created, with an identifier of `data.built_in.{class_name}`. The built-int types are:

- Core types defined in `core.py`, `PayloadData`, `StringData`, `BytesData`
- Abstract collection types in the `data.built_in.collection.abc` sub-module, one-to-one related with the standard libraries `abc` collections
- Implemented collection types in `data.built_in.collection.data_types` sub-module, namely `ListData`, `TupleData`, `DictData`, `OrderedDictData`, `SetData`, `FrozenSetData`, `QueueData`
- Number types defined in `data.built_in.numbers` sub-module, one-to-one related with the `numbers` module in the standard library. These are `NumberData`, `ComplexData`, `RealData`, `RationalData`, `IntegerData`.  

The types are made to assert that a payload's type must be a sub-type of a base class. All the classes except the numbers assert that the payload type is correct. The `number` classes attempt to cast the payload to a correct default type if its type is incorrect.

While making this functionality, I noticed that some QoL could be made to improve setting inputs and getting outputs. `payload_to_data` dict, `data_to_payload` dict, `register_payload_to_data`-`register_payload_to_data_multi` functions are provided in `Data.py` for the developer to associate payload types to a certain data type.  With them, a virtual class-method named `register_payload_type(cls)` is defined in the `Data` class and called when registering the class in a `Session` for inheritance-based payload to data association. All the above built-in types register themselves, either when imported or using the inheritance method.

i.e
```python
register_payload_to_data_multi(
    {
        list: ListData,
        tuple: TupleData,
        dict: DictData,
        OrderedDict: OrderedDictData,
        set: SetData,
        frozenset: FrozenSetData,
        deque: QueueData,
    }
)
```
Using the above, these functions have been implemented in the `Node` class.

<details>
    <summary>Code</summary>

```python
def set_output_payload(self, index: int, payload):
        """
        Wrapper of :code:`set_output_val()` that creates the data type from the payload type.
        
        Data and payload types must be associated with register_payload_to_data found in Data module.
        
        This function assumes the derived Data type's constructor works at least with a payload argument.
        Defaults to the base Data type if an association isn't found 
        """
        
        data_type = payload_to_data.get(type(payload))
        data = data_type(payload) if data_type else Data(payload)
        
        self.set_output_val(index, data)

def input_payload(self, index: int):
        """
        Returns the payload residing at the data input of given index.

        Do not call on exec inputs
        """
        
        data = self.input(index)
        
        return data.payload if data else None
```
</details>

The above functions 'skip' over the need of manually instantiating a data class, provided that dataclass works with a constructor that only needs a payload.
 
(At this point, I'd like to say that the `input()` function might be needing a rename, since it can be confused with the `inputs` list, despite the fact that the first returns a `Data` instance and the second stores the ports)

Much of the functionality has been tested in a third `DataTypesBuiltIn` test defined in `data_objects.py`

### Quality of Life

Some other improvements include additional events in `Node`:
- `updated`: invoked when the `update()` function exits
- `output_updated`: invoked when an output is updated
- `progress_updated`: invoked when setting the progress in a node

Regarding the third point, a `ProgressState` class has been added in `RC.py` for defining the progress inside a node, for example when using threads or multi-processes. It's a simple class and the associated functions are defined in the PROGRESS section of `Node`.

Lastly, the `NodePortType` classes were made into `dataclasses`.

These are (hopefully :D) all the important changes and additions I've made in this PR.